### PR TITLE
Make the gapcursor work properly in the demo

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -48,14 +48,13 @@ let tableMenu = [
 menu.splice(2, 0, [new Dropdown(tableMenu, {label: "Table"})])
 
 let doc = DOMParser.fromSchema(schema).parse(document.querySelector("#content"))
-let state = EditorState.create({doc, plugins: [
+let state = EditorState.create({doc, plugins: exampleSetup({schema, menuContent: menu}).concat(
   tableEditing(),
-  keymap(baseKeymap),
   keymap({
     "Tab": goToNextCell(1),
     "Shift-Tab": goToNextCell(-1)
   })
-].concat(exampleSetup({schema, menuContent: menu}))})
+)})
 
 window.view = new EditorView(document.querySelector("#editor"), {state})
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
 <link rel=stylesheet href="node_modules/prosemirror-view/style/prosemirror.css">
 <link rel=stylesheet href="node_modules/prosemirror-menu/style/menu.css">
 <link rel=stylesheet href="node_modules/prosemirror-example-setup/style/style.css">
+<link rel=stylesheet href="node_modules/prosemirror-gapcursor/style/gapcursor.css">
 <style>
   body {
     max-width: 50em;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prosemirror-schema-basic": "^0.23.0",
     "prosemirror-test-builder": "^0.23.0",
     "rimraf": "^2.6.1",
-    "rollup": "^0.41.0",
+    "rollup": "^0.45.0",
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-commonjs": "^6.0.0",
     "rollup-plugin-node-resolve": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,21 +19,21 @@
     }
   ],
   "dependencies": {
-    "prosemirror-keymap": "^0.22.0",
-    "prosemirror-model": "^0.22.0",
-    "prosemirror-state": "^0.22.0",
-    "prosemirror-transform": "^0.22.0",
-    "prosemirror-view": "^0.22.0"
+    "prosemirror-keymap": "^0.23.0",
+    "prosemirror-model": "^0.23.0",
+    "prosemirror-state": "^0.23.0",
+    "prosemirror-transform": "^0.23.0",
+    "prosemirror-view": "^0.23.0"
   },
   "devDependencies": {
     "buble": "^0.15.2",
     "ist": "^1.0.1",
     "mocha": "^3.4.2",
-    "prosemirror-commands": "^0.22.0",
-    "prosemirror-example-setup": "^0.22.0",
-    "prosemirror-menu": "^0.22.0",
-    "prosemirror-schema-basic": "^0.22.0",
-    "prosemirror-test-builder": "^0.22.0",
+    "prosemirror-commands": "^0.23.0",
+    "prosemirror-example-setup": "^0.23.0",
+    "prosemirror-menu": "^0.23.0",
+    "prosemirror-schema-basic": "^0.23.0",
+    "prosemirror-test-builder": "^0.23.0",
     "rimraf": "^2.6.1",
     "rollup": "^0.41.0",
     "rollup-plugin-buble": "^0.15.0",


### PR DESCRIPTION
This upgrades some things and changes the way plugins are ordered so that the gapcursor plugin works in the demo.