### PR TITLE
Use builddocs to put the API docs in the readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,15 @@
     "rollup-plugin-buble": "^0.15.0",
     "rollup-plugin-commonjs": "^6.0.0",
     "rollup-plugin-node-resolve": "^2.0.0",
-    "rollup-watch": "^3.2.0"
+    "rollup-watch": "^3.2.0",
+    "builddocs": "^0.3.0"
   },
   "scripts": {
     "test": "mocha test/test-*.js",
     "build_demo": "rollup -c",
     "build": "rimraf dist && buble -i src -o dist",
     "prepare": "npm run build",
-    "watch": "rollup -w -c"
+    "watch": "rollup -w -c",
+    "build_readme": "builddocs --name tables --format markdown --main src/README.md src/*.js > README.md"
   }
 }

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,62 @@
+# ProseMirror table module
+
+This module defines a schema extension to support tables with
+rowspan/colspan support, a custom selection class for cell selections
+in such a table, a plugin to manage such selections and enforce
+invariants on such tables, and a number of commands to work with
+tables.
+
+The top-level directory contains a `demo.js` and `index.html`, which
+can be built with `npm run build_demo` to show a simple demo of how the
+module can be used.
+
+## Documentation
+
+The module's main file exports everything you need to work with it.
+The first thing you'll probably want to do is create a table-enabled
+schema. That's what `tableNodes` is for:
+
+@tableNodes
+
+@tableEditing
+
+@CellSelection
+
+### Commands
+
+The following commands can be used to make table-editing functionality
+available to users.
+
+@addColumnBefore
+
+@addColumnAfter
+
+@deleteColumn
+
+@addRowBefore
+
+@addRowAfter
+
+@deleteRow
+
+@mergeCells
+
+@splitCell
+
+@setCellAttr
+
+@toggleHeaderRow
+
+@toggleHeaderColumn
+
+@toggleHeaderCell
+
+@goToNextCell
+
+@deleteTable
+
+### Utilities
+
+@fixTables
+
+@TableMap

--- a/src/cellselection.js
+++ b/src/cellselection.js
@@ -10,6 +10,11 @@ const {Fragment, Slice} = require("prosemirror-model")
 const {inSameTable, pointsAtCell, setAttr} = require("./util")
 const {TableMap} = require("./tablemap")
 
+// ::- A [`Selection`](http://prosemirror.net/docs/ref/#state.Selection)
+// subclass that represents a cell selection spanning part of a table.
+// With the plugin enabled, these will be created when the user
+// selects across cells, and will be drawn by giving selected cells a
+// `selectedCell` CSS class.
 class CellSelection extends Selection {
   // :: (ResolvedPos, ?ResolvedPos)
   // A table selection is identified by its anchor and head cells. The
@@ -29,7 +34,13 @@ class CellSelection extends Selection {
       return new SelectionRange(doc.resolve(from), doc.resolve(from + cell.content.size))
     })
     super(ranges[0].$from, ranges[0].$to, ranges)
+    // :: ResolvedPos
+    // A resolved position pointing _in front of_ the anchor cell (the one
+    // that doesn't move when extending the selection).
     this.$anchorCell = $anchorCell
+    // :: ResolvedPos
+    // A resolved position pointing in front of the head cell (the one
+    // moves when extending the selection).
     this.$headCell = $headCell
   }
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -356,15 +356,18 @@ function toggleHeader(type) {
 
 // :: (EditorState, dispatch: ?(tr: Transaction)) → bool
 // Toggles whether the selected row contains header cells.
-exports.toggleHeaderRow = toggleHeader("row")
+let toggleHeaderRow = toggleHeader("row")
+exports.toggleHeaderRow = toggleHeaderRow
 
 // :: (EditorState, dispatch: ?(tr: Transaction)) → bool
 // Toggles whether the selected column contains header cells.
-exports.toggleHeaderColumn = toggleHeader("column")
+let toggleHeaderColumn = toggleHeader("column")
+exports.toggleHeaderColumn = toggleHeaderColumn
 
 // :: (EditorState, dispatch: ?(tr: Transaction)) → bool
 // Toggles whether the selected cells are header cells.
-exports.toggleHeaderCell = toggleHeader("cell")
+let toggleHeaderCell = toggleHeader("cell")
+exports.toggleHeaderCell = toggleHeaderCell
 
 function findNextCell($cell, dir) {
   if (dir < 0) {

--- a/src/copypaste.js
+++ b/src/copypaste.js
@@ -20,7 +20,7 @@ const {tableNodeTypes} = require("./schema")
 
 // Utilities to help with copying and pasting table cells
 
-// :: (Slice) → ?{width: number, height: number, rows: [Fragment]}
+// : (Slice) → ?{width: number, height: number, rows: [Fragment]}
 // Get a rectangular area of cells from a slice, or null if the outer
 // nodes of the slice aren't table cells or rows.
 exports.pastedCells = function(slice) {
@@ -49,7 +49,7 @@ exports.pastedCells = function(slice) {
   return ensureRectangular(schema, rows)
 }
 
-// :: [Fragment] → {width: number, height: number, rows: [Fragment]}
+// : [Fragment] → {width: number, height: number, rows: [Fragment]}
 // Compute the width and height of a set of cells, and make sure each
 // row has the same number of cells.
 function ensureRectangular(schema, rows) {
@@ -81,7 +81,7 @@ let fitSlice = exports.fitSlice = function(nodeType, slice) {
   return tr.doc
 }
 
-// :: ({width: number, height: number, rows: [Fragment]}, number, number) → {width: number, height: number, rows: [Fragment]}
+// : ({width: number, height: number, rows: [Fragment]}, number, number) → {width: number, height: number, rows: [Fragment]}
 // Clip or extend (repeat) the given set of cells to cover the given
 // width and height. Will clip rowspan/colspan cells at the edges when
 // they stick out.

--- a/src/fixtables.js
+++ b/src/fixtables.js
@@ -36,7 +36,7 @@ function changedDescendants(old, cur, offset, f) {
 // provided, that is assumed to hold a previous, known-good state,
 // which will be used to avoid re-scanning unchanged parts of the
 // document.
-exports.fixTables = function(state, oldState) {
+function fixTables(state, oldState) {
   let tr, check = (node, pos) => {
     if (node.type.spec.tableRole == "table") tr = fixTable(state, node, pos, tr)
   }
@@ -44,8 +44,9 @@ exports.fixTables = function(state, oldState) {
   else if (oldState.doc != state.doc) changedDescendants(oldState.doc, state.doc, 0, check)
   return tr
 }
+exports.fixTables = fixTables
 
-// :: (EditorState, Node, number, ?Transaction) → ?Transaction
+// : (EditorState, Node, number, ?Transaction) → ?Transaction
 // Fix the given table, if necessary. Will append to the transaction
 // it was given, if non-null, or create a new one if necessary.
 let fixTable = exports.fixTable = function(state, table, tablePos, tr) {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,19 @@ const {tableNodes} = require("./schema")
 const commands = require("./commands")
 const {TableMap} = require("./tablemap")
 
-exports.tableEditing = function() {
+// :: () → Plugin
+//
+// Creates a [plugin](http://prosemirror.net/docs/ref/#state.Plugin)
+// that, when added to an editor, enables cell-selection, handles
+// cell-based copy/paste, and makes sure tables stay well-formed (each
+// row has the same width, and cells don't overlap).
+//
+// You should probably put this plugin near the end of your array of
+// plugins, since it handles mouse and arrow key events in tables
+// rather broadly, and other plugins, like the gap cursor or the
+// column-width dragging plugin, might want to get a turn first to
+// perform more specific behavior.
+function tableEditing() {
   return new Plugin({
     key,
 
@@ -57,6 +69,7 @@ exports.tableEditing = function() {
     }
   })
 }
+exports.tableEditing = tableEditing
 
 exports.TableMap = TableMap;
 exports.tableNodes = tableNodes

--- a/src/schema.js
+++ b/src/schema.js
@@ -25,8 +25,12 @@ function setCellAttrs(node, extraAttrs) {
 }
 
 // :: (Object) → Object
-// Create a set of node specs for `table`, `table_row`, and
-// `table_cell` nodes as used by this module.
+//
+// This function creates a set of [node
+// specs](http://prosemirror.net/docs/ref/#model.SchemaSpec.nodes) for
+// `table`, `table_row`, and `table_cell` nodes types as used by this
+// module. The result can then be added to the set of nodes when
+// creating a a schema.
 //
 //   options::- The following options are understood:
 //

--- a/src/tablemap.js
+++ b/src/tablemap.js
@@ -39,14 +39,18 @@ class Rect {
 }
 exports.Rect = Rect
 
+// ::- A table map describes the structore of a given table. To avoid
+// recomputing them all the time, they are cached per table node. To
+// be able to do that, positions saved in the map are relative to the
+// start of the table, rather than the start of the document.
 class TableMap {
   constructor(width, height, map, problems) {
-    // The width of the table
+    // :: number The width of the table
     this.width = width
-    // Its height
+    // :: number The table's height
     this.height = height
-    // A width * height array with the start position of the cell
-    // covering that part of the table in each slot
+    // :: [number] A width * height array with the start position of
+    // the cell covering that part of the table in each slot
     this.map = map
     // An optional array of problems (cell overlap or non-rectangular
     // shape) for the table, used by the table normalizer.


### PR DESCRIPTION
This uses [builddocs](https://github.com/marijnh/builddocs) to extract doc comments from the code and build a README with API docs -- making it easier to keep the doc comments and the README in sync. It means that editing the README should now be done in `src/README.md`, which is a template from which the top README.md is generated.

Would this work for you or do you have a preferred tool/process for this?