### PR TITLE
Add a plugin for column-resizing

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -49,7 +49,7 @@ menu.splice(2, 0, [new Dropdown(tableMenu, {label: "Table"})])
 
 let doc = DOMParser.fromSchema(schema).parse(document.querySelector("#content"))
 let state = EditorState.create({doc, plugins: exampleSetup({schema, menuContent: menu}).concat(
-  tableEditing(),
+  tableEditing({schema}),
   keymap({
     "Tab": goToNextCell(1),
     "Shift-Tab": goToNextCell(-1)

--- a/demo.js
+++ b/demo.js
@@ -10,7 +10,7 @@ import {MenuItem, Dropdown}  from "prosemirror-menu"
 import {addColumnAfter, addColumnBefore, deleteColumn, addRowAfter, addRowBefore, deleteRow,
         mergeCells, splitCell, setCellAttr, toggleHeaderRow, toggleHeaderColumn, toggleHeaderCell,
         goToNextCell, deleteTable}  from "./src/commands"
-import {tableEditing, columnResizing, tableNodes}  from "./src"
+import {tableEditing, columnResizing, tableNodes, fixTables}  from "./src"
 
 let schema = new Schema({
   nodes: baseSchema.spec.nodes.append(tableNodes({
@@ -50,12 +50,14 @@ menu.splice(2, 0, [new Dropdown(tableMenu, {label: "Table"})])
 let doc = DOMParser.fromSchema(schema).parse(document.querySelector("#content"))
 let state = EditorState.create({doc, plugins: exampleSetup({schema, menuContent: menu}).concat(
   columnResizing(),
-  tableEditing({schema}),
+  tableEditing(),
   keymap({
     "Tab": goToNextCell(1),
     "Shift-Tab": goToNextCell(-1)
   })
 )})
+let fix = fixTables(state)
+if (fix) state = state.apply(fix)
 
 window.view = new EditorView(document.querySelector("#editor"), {state})
 

--- a/demo.js
+++ b/demo.js
@@ -10,7 +10,7 @@ import {MenuItem, Dropdown}  from "prosemirror-menu"
 import {addColumnAfter, addColumnBefore, deleteColumn, addRowAfter, addRowBefore, deleteRow,
         mergeCells, splitCell, setCellAttr, toggleHeaderRow, toggleHeaderColumn, toggleHeaderCell,
         goToNextCell, deleteTable}  from "./src/commands"
-import {tableEditing, tableNodes}  from "./src"
+import {tableEditing, columnResizing, tableNodes}  from "./src"
 
 let schema = new Schema({
   nodes: baseSchema.spec.nodes.append(tableNodes({
@@ -49,6 +49,7 @@ menu.splice(2, 0, [new Dropdown(tableMenu, {label: "Table"})])
 
 let doc = DOMParser.fromSchema(schema).parse(document.querySelector("#content"))
 let state = EditorState.create({doc, plugins: exampleSetup({schema, menuContent: menu}).concat(
+  columnResizing(),
   tableEditing({schema}),
   keymap({
     "Tab": goToNextCell(1),

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     padding: 5px 15px;
   }
   .ProseMirror table {
-    margin: -1px;
+    margin: 0;
   }
   .ProseMirror th, .ProseMirror td {
     min-width: 1em;
@@ -29,8 +29,6 @@
     padding: 3px 5px;
   }
   .ProseMirror .tableWrapper {
-    border: 1px solid #ddd;
-    padding: -1px;
     margin: 1em 0;
   }
   .ProseMirror th {

--- a/index.html
+++ b/index.html
@@ -21,12 +21,17 @@
     padding: 5px 15px;
   }
   .ProseMirror table {
-    margin: 1em 0;
+    margin: -1px;
   }
   .ProseMirror th, .ProseMirror td {
     min-width: 1em;
     border: 1px solid #ddd;
     padding: 3px 5px;
+  }
+  .ProseMirror .tableWrapper {
+    border: 1px solid #ddd;
+    padding: -1px;
+    margin: 1em 0;
   }
   .ProseMirror th {
     font-weight: bold;

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
   <h2>Example content</h2>
   <p>The table:</p>
   <table>
-    <tr><th colspan=3>Wide header</td></tr>
+    <tr><th colspan=3 data-colwidth="100,0,0">Wide header</td></tr>
     <tr><td>One</td><td>Two</td><td>Three</td></tr>
     <tr><td>Four</td><td>Five</td><td>Six</td></tr>
   </table>

--- a/src/columnresizing.js
+++ b/src/columnresizing.js
@@ -1,0 +1,205 @@
+const {Plugin, PluginKey} = require("prosemirror-state")
+const {Decoration, DecorationSet} = require("prosemirror-view")
+const {cellAround, pointsAtCell, setAttr} = require("./util")
+const {TableMap} = require("./tablemap")
+const {TableView, updateColumns} = require("./tableview")
+const {tableNodeTypes} = require("./schema")
+
+const key = new PluginKey("tableColumnResizing")
+
+exports.columnResizing = function({handleWidth=5, cellMinWidth=25} = {}) {
+  let plugin = new Plugin({
+    key,
+    state: {
+      init(_, state) {
+        this.spec.props.nodeViews[tableNodeTypes(state.schema).table.name] =
+          node => new TableView(node, cellMinWidth)
+        return new ResizeState(-1, false)
+      },
+      apply(tr, prev) {
+        return prev.apply(tr)
+      }
+    },
+    props: {
+      attributes(state) {
+        let pluginState = key.getState(state)
+        return pluginState.activeHandle > -1 ? {class: "resize-cursor"} : null
+      },
+
+      handleDOMEvents: {
+        mousemove(view, event) { handleMouseMove(view, event, handleWidth, cellMinWidth) },
+        mouseleave(view) { handleMouseLeave(view) },
+        mousedown(view, event) { handleMouseDown(view, event, cellMinWidth) }
+      },
+
+      decorations(state) {
+        let pluginState = key.getState(state)
+        if (pluginState.activeHandle > -1) return handleDecorations(state, pluginState.activeHandle)
+      },
+
+      nodeViews: {}
+    }
+  })
+  return plugin
+}
+
+class ResizeState {
+  constructor(activeHandle, dragging) {
+    this.activeHandle = activeHandle
+    this.dragging = dragging
+  }
+
+  apply(tr) {
+    let state = this, action = tr.getMeta(key)
+    if (action && action.setHandle != null)
+      return new ResizeState(action.setHandle, null)
+    if (action && action.setDragging !== undefined)
+      return new ResizeState(state.activeHandle, action.setDragging)
+    if (state.activeHandle > -1 && tr.docChanged) {
+      let $handle = tr.doc.resolve(tr.mapping.map(state.activeHandle, -1))
+      if (!pointsAtCell($handle)) $handle = null
+      state = new ResizeState($handle.pos, state.dragging)
+    }
+    return state
+  }
+}
+
+function handleMouseMove(view, event, handleWidth, cellMinWidth) {
+  let pluginState = key.getState(view.state)
+
+  if (pluginState.dragging) {
+    displayColumnWidth(view, pluginState.activeHandle, draggedWidth(pluginState.dragging, event, cellMinWidth), cellMinWidth)
+  } else {
+    let target = domCellAround(event.target), cell = -1
+    if (target) {
+      let {left, right} = target.getBoundingClientRect()
+      if (event.clientX - left <= handleWidth)
+        cell = edgeCell(view, event, "left")
+      else if (right - event.clientX <= handleWidth)
+        cell = edgeCell(view, event, "right")
+    }
+    if (cell != pluginState.activeHandle) updateHandle(view, cell)
+  }
+}
+
+function handleMouseLeave(view) {
+  if (key.getState(view.state).activeHandle > -1) updateHandle(view, -1)
+}
+
+function handleMouseDown(view, event, cellMinWidth) {
+  let pluginState = key.getState(view.state)
+  if (pluginState.activeHandle > -1 && !pluginState.dragging) {
+    let cell = view.state.doc.nodeAt(pluginState.activeHandle)
+    let width = currentColWidth(view, pluginState.activeHandle, cell.attrs)
+    view.dispatch(view.state.tr.setMeta(key, {setDragging: {startX: event.clientX, startWidth: width}}))
+
+    function finish(event) {
+      window.removeEventListener("mouseup", finish)
+      window.removeEventListener("mousemove", move)
+      let pluginState = key.getState(view.state)
+      if (pluginState.dragging) {
+        updateColumnWidth(view, pluginState.activeHandle, draggedWidth(pluginState.dragging, event, cellMinWidth))
+        view.dispatch(view.state.tr.setMeta(key, {setDragging: null}))
+      }
+    }
+    function move(event) { if (!event.which) finish(event) }
+
+    window.addEventListener("mouseup", finish)
+    window.addEventListener("mousemove", move)
+    event.preventDefault()
+    return true
+  }
+}
+
+function currentColWidth(view, cellPos, {colspan, colwidth}) {
+  let width = colwidth && colwidth[colwidth.length - 1]
+  if (width) return width
+  // Not fixed, read current width from DOM
+  let domWidth = view.domAtPos(cellPos + 1).node.offsetWidth, parts = colspan
+  if (colwidth) for (let i = 0; i < colspan; i++) if (colwidth[i]) {
+    domWidth -= colwidth[i]
+    parts--
+  }
+  return domWidth / parts
+}
+
+function domCellAround(target) {
+  while (target && target.nodeName != "TD" && target.nodeName != "TH")
+    target = target.classList.contains("ProseMirror") ? null : target.parentNode
+  return target
+}
+
+function edgeCell(view, event, side) {
+  let {pos} = view.posAtCoords({left: event.clientX, top: event.clientY})
+  let $cell = cellAround(view.state.doc.resolve(pos))
+  if (!$cell) return -1
+  if (side == "right") return $cell.pos
+  let map = TableMap.get($cell.node(-1)), start = $cell.start(-1)
+  let index = map.map.indexOf($cell.pos - start)
+  return index % map.width == 0 ? -1 : start + map.map[index - 1]
+}
+
+function draggedWidth(dragging, event, cellMinWidth) {
+  let offset = event.clientX - dragging.startX
+  return Math.max(cellMinWidth, dragging.startWidth + offset)
+}
+
+function updateHandle(view, value) {
+  view.dispatch(view.state.tr.setMeta(key, {setHandle: value}))
+}
+
+function updateColumnWidth(view, cell, width) {
+  let $cell = view.state.doc.resolve(cell)
+  let table = $cell.node(-1), map = TableMap.get(table), start = $cell.start(-1)
+  let col = map.colCount($cell.pos - start) + $cell.nodeAfter.attrs.colspan - 1
+  let tr = view.state.tr
+  for (let row = 0; row < map.height; row++) {
+    let mapIndex = row * map.width + col
+    // Rowspanning cell that has already been handled
+    if (row && map.map[mapIndex] == map.map[mapIndex - map.width]) continue
+    let pos = map.map[mapIndex], {attrs} = table.nodeAt(pos)
+    let index = attrs.colspan == 1 ? 0 : col - map.colCount(pos)
+    if (attrs.colwidth && attrs.colwidth[index] == width) continue
+    let colwidth = attrs.colwidth ? attrs.colwidth.slice() : zeroes(attrs.colspan)
+    colwidth[index] = width
+    tr.setNodeType(start + pos, null, setAttr(attrs, "colwidth", colwidth))
+  }
+  if (tr.docChanged) view.dispatch(tr)
+}
+
+function displayColumnWidth(view, cell, width, cellMinWidth) {
+  let $cell = view.state.doc.resolve(cell)
+  let table = $cell.node(-1), start = $cell.start(-1)
+  let col = TableMap.get(table).colCount($cell.pos - start) + $cell.nodeAfter.attrs.colspan - 1
+  let dom = view.domAtPos($cell.start(-1)).node
+  while (dom.nodeName != "TABLE") dom = dom.parentNode
+  updateColumns(table, dom.firstChild, dom, cellMinWidth, col, width)
+}
+
+function zeroes(n) {
+  let result = []
+  for (let i = 0; i < n; i++) result.push(0)
+  return result
+}
+
+function handleDecorations(state, cell) {
+  let decorations = []
+  let $cell = state.doc.resolve(cell)
+  let table = $cell.node(-1), map = TableMap.get(table), start = $cell.start(-1)
+  let col = map.colCount($cell.pos - start) + $cell.nodeAfter.attrs.colspan
+  for (let row = 0; row < map.height; row++) {
+    let index = col + row * map.width - 1
+    // For positions that are have either a different cell or the end
+    // of the table to their right, and either the top of the table or
+    // a different cell above them, add a decoration
+    if ((col == map.width || map.map[index] != map.map[index + 1]) &&
+        (row == 0 || map.map[index - 1] != map.map[index - 1 - map.width])) {
+      let cellPos = map.map[index]
+      let pos = start + cellPos + table.nodeAt(cellPos).nodeSize - 1
+      let dom = document.createElement("div")
+      dom.className = "column-resize-handle"
+      decorations.push(Decoration.widget(pos, dom))
+    }
+  }
+  return DecorationSet.create(state.doc, decorations)
+}

--- a/src/fixtables.js
+++ b/src/fixtables.js
@@ -4,7 +4,7 @@
 // reported by `TableMap`.
 
 const {TableMap} = require("./tablemap")
-const {setAttr} = require("./util")
+const {setAttr, rmColSpan} = require("./util")
 const {tableNodeTypes} = require("./schema")
 
 // Helper for iterating through the nodes in a document that changed
@@ -63,7 +63,7 @@ let fixTable = exports.fixTable = function(state, table, tablePos, tr) {
     if (prob.type == "collision") {
       let cell = table.nodeAt(prob.pos)
       for (let j = 0; j < cell.attrs.rowspan; j++) mustAdd[prob.row + j] += prob.n
-      tr.setNodeType(tr.mapping.map(tablePos + 1 + prob.pos), null, setAttr(cell.attrs, "colspan", cell.attrs.colspan - prob.n))
+      tr.setNodeType(tr.mapping.map(tablePos + 1 + prob.pos), null, rmColSpan(cell.attrs, cell.attrs.colspan - prob.n, prob.n))
     } else if (prob.type == "missing") {
       mustAdd[prob.row] += prob.n
     } else if (prob.type == "overlong_rowspan") {

--- a/src/fixtables.js
+++ b/src/fixtables.js
@@ -69,6 +69,9 @@ let fixTable = exports.fixTable = function(state, table, tablePos, tr) {
     } else if (prob.type == "overlong_rowspan") {
       let cell = table.nodeAt(prob.pos)
       tr.setNodeType(tr.mapping.map(tablePos + 1 + prob.pos), null, setAttr(cell.attrs, "rowspan", cell.attrs.rowspan - prob.n))
+    } else if (prob.type == "colwidth mismatch") {
+      let cell = table.nodeAt(prob.pos)
+      tr.setNodeType(tr.mapping.map(tablePos + 1 + prob.pos), null, setAttr(cell.attrs, "colwidth", prob.colwidth))
     }
   }
   let first, last

--- a/src/fixtables.js
+++ b/src/fixtables.js
@@ -52,7 +52,7 @@ exports.fixTables = fixTables
 let fixTable = exports.fixTable = function(state, table, tablePos, tr) {
   let map = TableMap.get(table)
   if (!map.problems) return tr
-  if (!tr) tr = state.tr
+  if (!tr) tr = state.tr.setMeta("addToHistory", false)
 
   // Track which rows we must add cells to, so that we can adjust that
   // when fixing collisions.

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,8 @@ exports.tableEditing = tableEditing
 exports.TableMap = TableMap;
 exports.tableNodes = tableNodes
 exports.CellSelection = CellSelection
-exports.handlePaste = handlePaste;
+exports.fixTables = fixTables
+exports.handlePaste = handlePaste
 for (let name in commands) exports[name] = commands[name]
 
 exports.columnResizing = require("./columnresizing").columnResizing

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,6 @@ const {fixTables} = require("./fixtables")
 const {tableNodes} = require("./schema")
 const commands = require("./commands")
 const {TableMap} = require("./tablemap")
-const {tableNodeTypes} = require("./schema")
-const {TableView} = require("./tableview")
 
 // :: () → Plugin
 //
@@ -28,9 +26,7 @@ const {TableView} = require("./tableview")
 // rather broadly, and other plugins, like the gap cursor or the
 // column-width dragging plugin, might want to get a turn first to
 // perform more specific behavior.
-function tableEditing({schema, cellMinWidth=50}) {
-  let tableType = tableNodeTypes(schema).table
-
+function tableEditing() {
   return new Plugin({
     key,
 
@@ -65,9 +61,7 @@ function tableEditing({schema, cellMinWidth=50}) {
 
       handlePaste,
 
-      handleDrop,
-
-      nodeViews: {[tableType.name](node) { return new TableView(node, cellMinWidth) }}
+      handleDrop
     },
 
     appendTransaction(_, oldState, state) {
@@ -82,3 +76,5 @@ exports.tableNodes = tableNodes
 exports.CellSelection = CellSelection
 exports.handlePaste = handlePaste;
 for (let name in commands) exports[name] = commands[name]
+
+exports.columnResizing = require("./columnresizing").columnResizing

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,8 @@ const {fixTables} = require("./fixtables")
 const {tableNodes} = require("./schema")
 const commands = require("./commands")
 const {TableMap} = require("./tablemap")
+const {tableNodeTypes} = require("./schema")
+const {TableView} = require("./tableview")
 
 // :: () → Plugin
 //
@@ -26,7 +28,9 @@ const {TableMap} = require("./tablemap")
 // rather broadly, and other plugins, like the gap cursor or the
 // column-width dragging plugin, might want to get a turn first to
 // perform more specific behavior.
-function tableEditing() {
+function tableEditing({schema, cellMinWidth=50}) {
+  let tableType = tableNodeTypes(schema).table
+
   return new Plugin({
     key,
 
@@ -61,7 +65,9 @@ function tableEditing() {
 
       handlePaste,
 
-      handleDrop
+      handleDrop,
+
+      nodeViews: {[tableType.name](node) { return new TableView(node, cellMinWidth) }}
     },
 
     appendTransaction(_, oldState, state) {

--- a/src/schema.js
+++ b/src/schema.js
@@ -76,7 +76,7 @@ function tableNodes(options) {
       tableRole: "table",
       group: options.tableGroup,
       parseDOM: [{tag: "table"}],
-      toDOM(node) { return ["div", {class: "tableWrapper"}, ["table", colGroup(node), ["tbody", 0]]] }
+      toDOM() { return ["table", ["tbody", 0]] }
     },
     table_row: {
       content: "(table_cell | table_header)*",
@@ -103,17 +103,6 @@ function tableNodes(options) {
   }
 }
 exports.tableNodes = tableNodes
-
-const col0 = ["col"]
-function colGroup(node) {
-  let group = ["colgroup"]
-  node.firstChild.forEach(node => {
-    let w = node.attrs.colwidth
-    for (let i = 0; i < node.attrs.colspan; i++)
-      group.push(w && w[i] ? ["col", {style: `width: ${w[i]}px`}] : col0)
-  })
-  return group
-}
 
 function tableNodeTypes(schema) {
   let result = schema.cached.tableNodeTypes

--- a/src/tablemap.js
+++ b/src/tablemap.js
@@ -237,13 +237,13 @@ function findBadColWidths(map, colWidths, table) {
     for (let j = 0; j < node.attrs.colspan; j++) {
       let col = (i + j) % map.width, colWidth = colWidths[col * 2]
       if (colWidth != null && (!node.attrs.colwidth || node.attrs.colwidth[j] != colWidth))
-        (updated || (updated = widthArray(node.attrs)))[j] = colWidth
-      if (updated) map.problems.unshift({type: "colwidth mismatch", pos, colwidth: updated})
+        (updated || (updated = freshColWidth(node.attrs)))[j] = colWidth
     }
+    if (updated) map.problems.unshift({type: "colwidth mismatch", pos, colwidth: updated})
   }
 }
 
-function widthArray(attrs) {
+function freshColWidth(attrs) {
   if (attrs.colwidth) return attrs.colwidth.slice()
   let result = []
   for (let i = 0; i < attrs.colspan; i++) result.push(0)

--- a/src/tablemap.js
+++ b/src/tablemap.js
@@ -207,3 +207,26 @@ function findWidth(table) {
   }
   return width
 }
+
+function findBadColWidths(map, colWidths, table) {
+  if (!map.problems) map.problems = []
+  for (let i = 0, seen = []; i < map.map.length; i++) {
+    let pos = map.map[i]
+    if (seen.indexOf(pos) > -1) continue
+    seen.push(pos)
+    let node = table.nodeAt(pos), updated = null
+    for (let j = 0; j < node.attrs.colspan; j++) {
+      let col = (i + j) % map.width, colWidth = colWidths[col * 2]
+      if (colWidth != null && (!node.attrs.colwidth || node.attrs.colwidth[j] != colWidth))
+        (updated || (updated = widthArray(node.attrs)))[j] = colWidth
+      if (updated) map.problems.unshift({type: "colwidth mismatch", pos, colwidth: updated})
+    }
+  }
+}
+
+function widthArray(attrs) {
+  if (attrs.colwidth) return attrs.colwidth.slice()
+  let result = []
+  for (let i = 0; i < attrs.colspan; i++) result.push(0)
+  return result
+}

--- a/src/tableview.js
+++ b/src/tableview.js
@@ -1,0 +1,46 @@
+class TableView {
+  constructor(node, cellMinWidth) {
+    this.node = node
+    this.cellMinWidth = cellMinWidth
+    this.dom = document.createElement("div")
+    this.dom.className = "tableWrapper"
+    this.table = this.dom.appendChild(document.createElement("table"))
+    this.colgroup = this.table.appendChild(document.createElement("colgroup"))
+    let totalWidth = updateColumns(node, this.colgroup, cellMinWidth)
+    this.table.style.minWidth = totalWidth + "px"
+    this.contentDOM = this.table.appendChild(document.createElement("tbody"))
+  }
+
+  update(node) {
+    if (node.type != this.node.type) return false
+    this.node = node
+    let totalWidth = updateColumns(node, this.colgroup, this.cellMinWidth)
+    this.table.style.minWidth = totalWidth + "px"
+    return true
+  }
+}
+exports.TableView = TableView
+
+function updateColumns(node, dom, cellMinWidth) {
+  let totalWidth = 0
+  let nextDOM = dom.firstChild, row = node.firstChild
+  for (let i = 0; i < row.childCount; i++) {
+    let {colspan, colwidth} = row.child(i).attrs
+    for (let j = 0; j < colspan; j++) {
+      let hasWidth = colwidth && colwidth[j], width = hasWidth ? hasWidth + "px" : ""
+      totalWidth += hasWidth || cellMinWidth
+      if (!nextDOM) {
+        dom.appendChild(document.createElement("col")).style.width = width
+      } else {
+        if (nextDOM && nextDOM.style.width != width) nextDOM.style.width = width
+        nextDOM = nextDOM.nextSibling
+      }
+    }
+  }
+  while (nextDOM) {
+    let after = nextDOM.nextSibling
+    nextDOM.parentNode.removeChild(nextDOM)
+    nextDOM = after
+  }
+  return totalWidth
+}

--- a/src/util.js
+++ b/src/util.js
@@ -53,9 +53,28 @@ exports.nextCell = function($pos, axis, dir) {
   return moved == null ? null : $pos.node(0).resolve(start + moved)
 }
 
-exports.setAttr = function(attrs, name, value) {
+let setAttr = exports.setAttr = function(attrs, name, value) {
   let result = {}
   for (let prop in attrs) result[prop] = attrs[prop]
   result[name] = value
+  return result
+}
+
+exports.rmColSpan = function(attrs, pos, n=1) {
+  let result = setAttr(attrs, "colspan", attrs.colspan - n)
+  if (result.colwidth) {
+    result.colwidth = result.colwidth.slice()
+    result.colwidth.splice(pos, n)
+    if (!result.colwidth.some(w => w > 0)) result.colwidth = null
+  }
+  return result
+}
+
+exports.addColSpan = function(attrs, pos, n=1) {
+  let result = setAttr(attrs, "colspan", attrs.colspan + n)
+  if (result.colwidth) {
+    result.colwidth = result.colwidth.slice()
+    for (let i = 0; i < n; i++) result.colwidth.splice(pos, 0, 0)
+  }
   return result
 }

--- a/style/tables.css
+++ b/style/tables.css
@@ -1,3 +1,6 @@
+.ProseMirror .tableWrapper {
+  overflow-x: auto;
+}
 .ProseMirror table {
   border-collapse: collapse;
   table-layout: fixed;

--- a/style/tables.css
+++ b/style/tables.css
@@ -5,16 +5,26 @@
   border-collapse: collapse;
   table-layout: fixed;
   width: 100%;
+  overflow: hidden;
 }
 .ProseMirror td, .ProseMirror th {
   vertical-align: top;
   box-sizing: border-box;
-  min-width: 50px;
-}
-/* Give selected cells a blue overlay */
-.ProseMirror .selectedCell {
   position: relative;
 }
+.ProseMirror .column-resize-handle {
+  position: absolute;
+  right: -2px; top: 0; bottom: 0;
+  width: 4px;
+  z-index: 20;
+  background-color: #adf;
+  pointer-events: none;
+}
+.ProseMirror.resize-cursor {
+  cursor: ew-resize;
+  cursor: col-resize;
+}
+/* Give selected cells a blue overlay */
 .ProseMirror .selectedCell:after {
   z-index: 2;
   position: absolute;

--- a/style/tables.css
+++ b/style/tables.css
@@ -9,6 +9,7 @@
 .ProseMirror td, .ProseMirror th {
   vertical-align: top;
   box-sizing: border-box;
+  min-width: 50px;
 }
 /* Give selected cells a blue overlay */
 .ProseMirror .selectedCell {

--- a/test/test-cellselection.js
+++ b/test/test-cellselection.js
@@ -69,4 +69,8 @@ describe("CellSelection.content", () => {
   it("cuts off cells sticking out vertically", () =>
      ist(selectionFor(table(tr(c11, c(1, 4), c(1, 2)), tr(cAnchor), tr(c(1, 2), cHead), tr(c11))).content(),
          slice(table(tr(c11, td({rowspan: 2}, p()), cEmpty), tr(c11, c11))), eq))
+
+  it("preserves column widths", () =>
+     ist(selectionFor(table(tr(c11, cAnchor, c11), tr(td({colspan: 3, colwidth: [100, 200, 300]}, p("x"))), tr(c11, cHead, c11))).content(),
+         slice(table(tr(c11), tr(td({colwidth: [200]}, p())), tr(c11))), eq))
 })

--- a/test/test-commands.js
+++ b/test/test-commands.js
@@ -82,6 +82,11 @@ describe("addColumnAfter", () => {
      test(doc(p("foo<cursor>")),
           addColumnAfter,
           null))
+
+  it("preserves column widths", () =>
+     test(table(tr(cAnchor, c11), tr(td({colspan: 2, colwidth: [100, 200]}, p("a")))),
+          addColumnAfter,
+          table(tr(cAnchor, cEmpty, c11), tr(td({colspan: 3, colwidth: [100, 0, 200]}, p("a"))))))
 })
 
 describe("addColumnBefore", () => {
@@ -151,6 +156,16 @@ describe("deleteColumn", () => {
      test(table(tr(c(1, 2), cAnchor, c11), tr(c11, cEmpty), tr(cHead, c11, c11)),
           deleteColumn,
           table(tr(c11), tr(cEmpty), tr(c11))))
+
+  it("leaves column widths intact", () =>
+     test(table(tr(c11, cAnchor, c11), tr(td({colspan: 3, colwidth: [100, 200, 300]}, p("y")))),
+          deleteColumn,
+          table(tr(c11, c11), tr(td({colspan: 2, colwidth: [100, 300]}, p("y"))))))
+
+  it("resets column width when all zeroes", () =>
+     test(table(tr(c11, cAnchor, c11), tr(td({colspan: 3, colwidth: [0, 200, 0]}, p("y")))),
+          deleteColumn,
+          table(tr(c11, c11), tr(td({colspan: 2}, p("y"))))))
 })
 
 describe("addRowAfter", () => {
@@ -294,6 +309,11 @@ describe("mergeCells", () => {
      test(table(tr(c11, cAnchor, c(1, 2), cEmpty, c11), tr(c11, cEmpty, cHead, c11)),
           mergeCells,
           table(tr(c11, td({rowspan: 2, colspan: 3}, p("x"), p("x"), p("x")), c11), tr(c11, c11))))
+
+  it("keeps the column width of the first col", () =>
+     test(table(tr(td({colwidth: [100]}, p("x<anchor>")), c11), tr(c11, cHead)),
+          mergeCells,
+          table(tr(td({colspan: 2, rowspan: 2, colwidth: [100, 0]}, p("x"), p("x"), p("x"), p("x"))), tr())))
 })
 
 describe("splitCell", () => {
@@ -326,6 +346,11 @@ describe("splitCell", () => {
      test(table(tr(c(4, 1)), tr(c11, td({rowspan: 2, colspan: 2}, p("foo<anchor>")), c11), tr(c11, c11)),
           splitCell,
           table(tr(c(4, 1)), tr(c11, td(p("foo")), cEmpty, c11), tr(c11, cEmpty, cEmpty, c11))))
+
+  it("distributes column widths", () =>
+     test(table(tr(td({colspan: 3, colwidth: [100, 0, 200]}, p("a<anchor>")))),
+          splitCell,
+          table(tr(td({colwidth: [100]}, p("a")), cEmpty, td({colwidth: [200]}, p())))))
 })
 
 describe("setCellAttr", () => {

--- a/test/test-copypaste.js
+++ b/test/test-copypaste.js
@@ -117,4 +117,9 @@ describe("insertCells", () => {
      test(table(tr(c11, cAnchor, c11), tr(c(2, 1), c11), tr(c11, c(2, 1))),
           table("<a>", tr(cEmpty), tr(cEmpty), tr(cEmpty), "<b>"),
           table(tr(c11, cEmpty, c11), tr(c11, cEmpty, c11), tr(c11, cEmpty, cEmpty))))
+
+  it("preserves widths when splitting", () =>
+     test(table(tr(c11, cAnchor, c11), tr(td({colspan: 3, colwidth: [100, 200, 300]}, p("x")))),
+          table("<a>", tr(cEmpty), tr(cEmpty), "<b>"),
+          table(tr(c11, cEmpty, c11), tr(td({colwidth: [100]}, p("x")), cEmpty, td({colwidth: [300]}, p())))))
 })

--- a/test/test-fixtable.js
+++ b/test/test-fixtable.js
@@ -1,8 +1,10 @@
 const ist = require("ist")
 const {EditorState} = require("prosemirror-state")
 
-const {doc, table, tr, c, c11, cEmpty, eq} = require("./build")
+const {doc, table, tr, td, p, c, c11, cEmpty, eq} = require("./build")
 const {fixTables} = require("../src/fixtables")
+
+let cw100 = td({colwidth: [100]}, p("x")), cw200 = td({colwidth: [200]}, p("x"))
 
 function fix(table) {
   let state = EditorState.create({doc: doc(table)})
@@ -43,5 +45,20 @@ describe("fixTable", () => {
   it("will fix a rowspan that sticks out of the table", () => {
     ist(fix(table(tr(c11, c11), tr(c(1, 2), c11))),
         table(tr(c11, c11), tr(c11, c11)), eq)
+  })
+
+  it("makes sure column widths are coherent", () => {
+    ist(fix(table(tr(c11, c11, cw200), tr(cw100, c11, c11))),
+        table(tr(cw100, c11, cw200), tr(cw100, c11, cw200)), eq)
+  })
+
+  it("can update column widths on colspan cells", () => {
+    ist(fix(table(tr(c11, c11, cw200), tr(c(3, 2)), tr())),
+        table(tr(c11, c11, cw200), tr(td({colspan: 3, rowspan: 2, colwidth: [0, 0, 200]}, p("x"))), tr()), eq)
+  })
+
+  it("will update the odd one out when column widths disagree", () => {
+    ist(fix(table(tr(cw100, cw100, cw100), tr(cw200, cw200, cw100), tr(cw100, cw200, cw200))),
+        table(tr(cw100, cw200, cw100), tr(cw100, cw200, cw100), tr(cw100, cw200, cw100)), eq)
   })
 })


### PR DESCRIPTION
This pull request does several things:

 - It add an attribute `colwidth` to table cells, which stores the width of the columns that the cell if part of. Each column can have either no fixed with or a width in pixels.

   I ended up storing this on the cells instead of the table because it makes it easier to make sure that a given width 'sticks' to the right column when the table is modified, and when cells are moved around. The table-fixing code makes sure column widths stay coherent by adjusting widths in the same column to the width of the majority of that column

 - It introduces a new plugin `columnResizing` which implements a table view that renders and updates `<col>` tags for tables to specify the column widths, and functionality for resize handles on column boundaries.

(I ended up including the patch from #10 in this because untangling it caused some conflicts. If that one is rejected, I'll update this branch to remove it.)