### PR TITLE
Don't disable history when fixing up tables

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -57,7 +57,7 @@ let state = EditorState.create({doc, plugins: exampleSetup({schema, menuContent:
   })
 )})
 let fix = fixTables(state)
-if (fix) state = state.apply(fix)
+if (fix) state = state.apply(fix.setMeta("addToHistory", false))
 
 window.view = new EditorView(document.querySelector("#editor"), {state})
 

--- a/src/fixtables.js
+++ b/src/fixtables.js
@@ -52,7 +52,7 @@ exports.fixTables = fixTables
 let fixTable = exports.fixTable = function(state, table, tablePos, tr) {
   let map = TableMap.get(table)
   if (!map.problems) return tr
-  if (!tr) tr = state.tr.setMeta("addToHistory", false)
+  if (!tr) tr = state.tr
 
   // Track which rows we must add cells to, so that we can adjust that
   // when fixing collisions.


### PR DESCRIPTION
It'll make it impossible to fully undo the changes that triggered the
fix.

Issue #8