### PR TITLE
Add flags to disable gap cursors inside table and row nodes

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -76,13 +76,15 @@ export function tableNodes(options) {
       tableRole: "table",
       group: options.tableGroup,
       parseDOM: [{tag: "table"}],
-      toDOM() { return ["table", ["tbody", 0]] }
+      toDOM() { return ["table", ["tbody", 0]] },
+      allowGapCursor: false
     },
     table_row: {
       content: "(table_cell | table_header)*",
       tableRole: "row",
       parseDOM: [{tag: "tr"}],
-      toDOM() { return ["tr", 0] }
+      toDOM() { return ["tr", 0] },
+      allowGapCursor: false
     },
     table_cell: {
       content: options.cellContent,


### PR DESCRIPTION
So that people can use this with the next release of prosemirror-gapcursor without problems. (See [this patch](https://github.com/ProseMirror/prosemirror-gapcursor/commit/89bb7d7304730f9da02252ba7950b591de99db34)).