### PR TITLE
Implement `createTable` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ available to users.
    Deletes the table around the selection, if any.
 
 
+ * **`createTable`**`(row: ?number = 1, col: ?number = 1, cellAttrs: ?Object = {}) → fn(EditorState, dispatch: ?fn(tr: Transaction)) → bool`\
+   Creates a table with specified size and attrs, then focus to first cell.
+
+
 ### Utilities
 
  * **`fixTables`**`(state: EditorState, oldState: ?EditorState) → ?Transaction`\

--- a/src/README.md
+++ b/src/README.md
@@ -55,6 +55,8 @@ available to users.
 
 @deleteTable
 
+@createTable
+
 ### Utilities
 
 @fixTables

--- a/src/commands.js
+++ b/src/commands.js
@@ -410,9 +410,9 @@ export function deleteTable(state, dispatch) {
   return false
 }
 
-// :: (number, number, ?Object) → (EditorState, dispatch: ?(tr: Transaction)) → bool
+// :: (?number, ?number, ?Object) → (EditorState, dispatch: ?(tr: Transaction)) → bool
 // Creates a table with specified size and attrs, then focus to first cell.
-export function createTable(row, col, cellAttrs = {}) {
+export function createTable(row = 1, col = 1, cellAttrs = {}) {
   return function(state, dispatch) {
     const { tr, schema } = state
     const tableType = schema.nodes.table

--- a/src/commands.js
+++ b/src/commands.js
@@ -409,3 +409,26 @@ export function deleteTable(state, dispatch) {
   }
   return false
 }
+
+// :: (number, number, ?Object) → (EditorState, dispatch: ?(tr: Transaction)) → bool
+// Creates a table with specified size and attrs, then focus to first cell.
+export function createTable(row, col, cellAttrs = {}) {
+  return function(state, dispatch) {
+    const { tr, schema } = state
+    const tableType = schema.nodes.table
+    const rowType = schema.nodes.table_row
+    const cellType = schema.nodes.table_cell
+    const cellNode = cellType.createAndFill(cellAttrs)
+    const cells = []
+    for (let i = 0; i < col; i++) cells.push(cellNode)
+    const rowNode = rowType.create(null, Fragment.from(cells))
+    const rows = []
+    for (let i = 0; i < row; i++) rows.push(rowNode)
+    const tableNode = tableType.create(null, Fragment.from(rows))
+    const newSelection = TextSelection.create(tr.doc, transaction.mapping.maps[0].ranges[0] + 1)
+    if (dispatch) {
+      dispatch(tr.replaceSelectionWith(tableNode).setSelection(newSelection).scrollIntoView())
+    }
+    return true
+  }
+}


### PR DESCRIPTION
Closes #26 

This module is awesome! Since we already have `addColumn` and `deleteColumn`, mirroring `deleteTable` with `createTable` seems to make sense.

This command is designed to accept row counts, column counts and cell attributes. For common use case, creating a `m x n` table from popover or user input can be simply implemented by calling `createTable(m, n)`, with text selection inside first cell as default.