### PR TITLE
Treat node selections of table cells similar to cell selections

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -22,6 +22,8 @@ export function selectionCell(state) {
   let sel = state.selection
   if (sel.$anchorCell) {
     return sel.$anchorCell.pos > sel.$headCell.pos ? sel.$anchorCell : sel.$headCell;
+  } else if (sel.node && sel.node.type.spec.tableRole == "cell") {
+    return sel.$anchor
   }
   return cellAround(sel.$head) || cellNear(sel.$head)
 }


### PR DESCRIPTION
Fixes broken test: addColumnAfter properly handles a cell node selection