### PR TITLE
It should be possible to split col or row spanning cell which has cursor but not cell-selection.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -12,6 +12,12 @@ export function cellAround($pos) {
   return null
 }
 
+export function cellWrapping($pos) {
+  for (var d = $pos.depth - 1; d > 0; d--)
+    if ($pos.node(d).type.spec.tableRole == "cell") return $pos.node(d)
+  return null
+}
+
 export function isInTable(state) {
   let $head = state.selection.$head
   for (let d = $head.depth; d > 0; d--) if ($head.node(d).type.spec.tableRole == "row") return true

--- a/test/test-commands.js
+++ b/test/test-commands.js
@@ -317,10 +317,15 @@ describe("mergeCells", () => {
 })
 
 describe("splitCell", () => {
-  it("does nothing when there isn't a cell selection", () =>
+  it("does nothing when cursor is inside of a cell with attributes colspan = 1 and rowspan = 1", () =>
      test(table(tr(cCursor, c11)),
           splitCell,
           null))
+
+  it("can split when col-spanning cell with cursor", () =>
+     test(table(tr(td({colspan: 2}, p("foo<cursor>")), c11)),
+           splitCell,
+           table(tr(td(p("foo")), cEmpty, c11))))
 
   it("does nothing for a multi-cell selection", () =>
      test(table(tr(cAnchor, cHead, c11)),


### PR DESCRIPTION
Currently its not possible to split spanning cell with cursor in it. PR fixes this issue.