### PR TITLE
Fix finicky drag handle bug

### DIFF
--- a/src/columnresizing.js
+++ b/src/columnresizing.js
@@ -147,7 +147,8 @@ function domCellAround(target) {
 }
 
 function edgeCell(view, event, side) {
-  let {pos} = view.posAtCoords({left: event.clientX, top: event.clientY})
+  const buffer = side == 'right' ? -5 : 5; // Fixes finicky bug where posAtCoords could return wrong pos.
+  let {pos} = view.posAtCoords({left: event.clientX + buffer, top: event.clientY})
   let $cell = cellAround(view.state.doc.resolve(pos))
   if (!$cell) return -1
   if (side == "right") return $cell.pos


### PR DESCRIPTION
Not sure if this is the "right" fix or if there is a deeper issue with `posAtCoords`. This fix worked for me and was a pain to find.

In some cases `posAtCoords` was returning the wrong `pos`. This resulted in the drag handle jumping one column over. The fix is to add a buffer so that `posAtCoords` is not given a `left` value that is very much on the border between two cells.

BEFORE FIX (notice resize-handle jumps to the left):
![aug-30-2018 23-55-40](https://user-images.githubusercontent.com/1568246/44891965-3ba9b780-acb0-11e8-9baf-bb96c6d71f68.gif)

AFTER FIX (smooth as butter):
![aug-30-2018 23-54-50](https://user-images.githubusercontent.com/1568246/44891941-20d74300-acb0-11e8-9fa4-9dc4c59d0b7b.gif)