### PR TITLE
Respect tableRole when fixing a table

### DIFF
--- a/src/fixtables.js
+++ b/src/fixtables.js
@@ -83,12 +83,17 @@ export function fixTable(state, table, tablePos, tr) {
   // was taken out of the table, add cells at the start of the row
   // after the bite. Otherwise add them at the end).
   for (let i = 0, pos = tablePos + 1; i < map.height; i++) {
-    let end = pos + table.child(i).nodeSize
+    let row = table.child(i)
+    let end = pos + row.nodeSize
     let add = mustAdd[i]
     if (add > 0) {
+      let tableNodeType = 'cell';
+      if (row.firstChild) {
+        tableNodeType = row.firstChild.type.spec.tableRole
+      }
       let nodes = []
       for (let j = 0; j < add; j++)
-        nodes.push(tableNodeTypes(state.schema).cell.createAndFill())
+        nodes.push(tableNodeTypes(state.schema)[tableNodeType].createAndFill())
       let side = (i == 0 || first == i - 1) && last == i ? pos + 1 : end - 1
       tr.insert(tr.mapping.map(side), nodes)
     }

--- a/test/test-fixtable.js
+++ b/test/test-fixtable.js
@@ -1,7 +1,7 @@
 const ist = require("ist")
 const {EditorState} = require("prosemirror-state")
 
-const {doc, table, tr, td, p, c, c11, cEmpty, eq} = require("./build")
+const {doc, table, tr, td, p, c, c11, cEmpty, h11, hEmpty, eq} = require("./build")
 const {fixTables} = require("../dist/")
 
 let cw100 = td({colwidth: [100]}, p("x")), cw200 = td({colwidth: [200]}, p("x"))
@@ -61,4 +61,12 @@ describe("fixTable", () => {
     ist(fix(table(tr(cw100, cw100, cw100), tr(cw200, cw200, cw100), tr(cw100, cw200, cw200))),
         table(tr(cw100, cw200, cw100), tr(cw100, cw200, cw100), tr(cw100, cw200, cw100)), eq)
   })
+
+  it('respects table role when inserting a cell', () => {
+    ist(
+      fix(table(tr(h11), tr(c11, c11), tr(c(3, 1)))),
+      table(tr(h11, hEmpty, hEmpty), tr(cEmpty, c11, c11), tr(c(3, 1))),
+      eq
+    );
+  });
 })


### PR DESCRIPTION
Currently `fixTable` will always inserts a `cell` when trying to patch a table, instead this looks at the current row's role and tries to match it.