### PR TITLE
Add option to allow table node selection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ schema. That's what `tableNodes` is for:
             object that's used to render the cell's DOM.
 
 
- * **`tableEditing`**`() → Plugin`\
+ * **`tableEditing`**`({allowTableNodeSelection: false}) → Plugin`\
    Creates a [plugin](http://prosemirror.net/docs/ref/#state.Plugin)
    that, when added to an editor, enables cell-selection, handles
    cell-based copy/paste, and makes sure tables stay well-formed (each

--- a/src/cellselection.js
+++ b/src/cellselection.js
@@ -272,7 +272,7 @@ function isTextSelectionAcrossCells({$from, $to}) {
   return fromCellBoundaryNode !== toCellBoundaryNode && $to.parentOffset === 0
 }
 
-export function normalizeSelection(state, tr) {
+export function normalizeSelection(state, tr, allowTableNodeSelection) {
   let sel = (tr || state).selection, doc = (tr || state).doc, normalize, role
   if (sel instanceof NodeSelection && (role = sel.node.type.spec.tableRole)) {
     if (role == "cell" || role == "header_cell") {
@@ -280,7 +280,7 @@ export function normalizeSelection(state, tr) {
     } else if (role == "row") {
       let $cell = doc.resolve(sel.from + 1)
       normalize = CellSelection.rowSelection($cell, $cell)
-    } else {
+    } else if (!allowTableNodeSelection) {
       let map = TableMap.get(sel.node), start = sel.from + 1
       let lastCell = start + map.map[map.width * map.height - 1]
       normalize = CellSelection.create(doc, start + 1, lastCell)

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ import {fixTables} from "./fixtables"
 // rather broadly, and other plugins, like the gap cursor or the
 // column-width dragging plugin, might want to get a turn first to
 // perform more specific behavior.
-export function tableEditing() {
+export function tableEditing({ allowTableNodeSelection = false } = {}) {
   return new Plugin({
     key,
 
@@ -60,7 +60,7 @@ export function tableEditing() {
     },
 
     appendTransaction(_, oldState, state) {
-      return normalizeSelection(state, fixTables(state, oldState))
+      return normalizeSelection(state, fixTables(state, oldState), allowTableNodeSelection)
     }
   })
 }


### PR DESCRIPTION
Adds the option `allowTableNodeSelection` to the `tableEditing` plugin. When this option is set to `true`, the selection normalization routine will not convert a `NodeSelection`  of the table node to a `CellSelection` of all cells in the table.

Includes four new unit tests for the normalization of node selections.

Addresses #53