### PR TITLE
Replace current toggleHeader logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ available to users.
    Toggles whether the selected cells are header cells.
 
 
+ * **`toggleHeader`**`(type: string, options: ?{useDeprecatedLogic: bool}) → fn(EditorState, dispatch: ?fn(tr: Transaction)) → bool`\
+   Toggles row|column header cells in a table always on the first row|column
+   to use the old, not support anymore, logic pass useDeprecatedLogic as true
+
+
  * **`goToNextCell`**`(direction: number) → fn(EditorState, dispatch: ?fn(tr: Transaction)) → bool`\
    Returns a command for selecting the next (direction=1) or previous
    (direction=-1) cell in a table.

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ available to users.
 
 
  * **`toggleHeader`**`(type: string, options: ?{useDeprecatedLogic: bool}) → fn(EditorState, dispatch: ?fn(tr: Transaction)) → bool`\
-   Toggles row|column header cells in a table always on the first row|column
-   to use the old, not support anymore, logic pass useDeprecatedLogic as true
+   Toggles between row/column header and normal cells (Only applies to first row/column).
+   For deprecated behavior pass useDeprecatedLogic in options with true.
 
 
  * **`goToNextCell`**`(direction: number) → fn(EditorState, dispatch: ?fn(tr: Transaction)) → bool`\

--- a/src/README.md
+++ b/src/README.md
@@ -51,6 +51,8 @@ available to users.
 
 @toggleHeaderCell
 
+@toggleHeader
+
 @goToNextCell
 
 @deleteTable

--- a/src/commands.js
+++ b/src/commands.js
@@ -378,8 +378,8 @@ function isHeaderEnabledByType(type, rect, types) {
 }
 
 // :: (string, ?{ useDeprecatedLogic: bool }) → (EditorState, dispatch: ?(tr: Transaction)) → bool
-// Toggles row|column header cells in a table always on the first row|column
-// to use the old, not support anymore, logic pass useDeprecatedLogic as true
+// Toggles between row/column header and normal cells (Only applies to first row/column).
+// For deprecated behavior pass useDeprecatedLogic in options with true.
 export function toggleHeader(type, options) {
   options = options || { useDeprecatedLogic: false }
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -366,7 +366,6 @@ function isHeaderEnabledByType(type, rect, types) {
     right: type == "row" ? rect.map.width : 1,
     bottom: type == "column" ? rect.map.height : 1,
   })
-  const map = rect.map
 
   for (let i = 0; i < cellPositions.length; i++) {
     const cell = rect.table.nodeAt(cellPositions[i])

--- a/src/commands.js
+++ b/src/commands.js
@@ -379,7 +379,7 @@ function isHeaderEnabledByType(type, rect, types) {
 
 // :: (string, ?{ useDeprecatedLogic: bool }) → (EditorState, dispatch: ?(tr: Transaction)) → bool
 // Toggles between row/column header and normal cells (Only applies to first row/column).
-// For deprecated behavior pass useDeprecatedLogic in options with true.
+// For deprecated behavior pass `useDeprecatedLogic` in options with true.
 export function toggleHeader(type, options) {
   options = options || { useDeprecatedLogic: false }
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -391,16 +391,20 @@ export function toggleHeader(type, options) {
     if (dispatch) {
       let types = tableNodeTypes(state.schema)
       let rect = selectedRect(state), tr = state.tr
-      let isHeaderEnabled = type === "column" ? isHeaderEnabledByType("row", rect, types) :
-                            type === "row"    ? isHeaderEnabledByType("column", rect, types) : false
+
+      let isHeaderRowEnabled = isHeaderEnabledByType("row", rect, types)
+      let isHeaderColumnEnabled = isHeaderEnabledByType("column", rect, types)
+
+      let isHeaderEnabled = type === "column" ? isHeaderRowEnabled :
+                            type === "row"    ? isHeaderColumnEnabled : false
 
       let selectionStartsAt = isHeaderEnabled ? 1 : 0
 
       let cellsRect = type == "column" ? new Rect(0, selectionStartsAt, 1, rect.map.height) :
                       type == "row" ? new Rect(selectionStartsAt, 0, rect.map.width, 1) : rect
 
-      let newType = type == "column" ? isHeaderEnabledByType("column", rect, types) ? types.cell : types.header_cell :
-                    type == "row" ? isHeaderEnabledByType("row", rect, types) ? types.cell : types.header_cell : types.cell
+      let newType = type == "column" ? isHeaderColumnEnabled ? types.cell : types.header_cell :
+                    type == "row" ? isHeaderRowEnabled ? types.cell : types.header_cell : types.cell
 
       rect.map.cellsInRect(cellsRect).forEach(relativeCellPos => {
         const cellPos = relativeCellPos + rect.tableStart

--- a/test/test-commands.js
+++ b/test/test-commands.js
@@ -3,7 +3,7 @@ const {EditorState} = require("prosemirror-state")
 
 const {doc, table, tr, p, td, th, c, h, c11, h11, cEmpty, hEmpty, cCursor, hCursor, cHead, cAnchor, eq, selectionFor} = require("./build")
 const {addColumnAfter, addColumnBefore, deleteColumn, addRowAfter, addRowBefore, deleteRow,
-       mergeCells, splitCell, setCellAttr, toggleHeaderRow, toggleHeaderColumn} = require("../dist/")
+       mergeCells, splitCell, setCellAttr, toggleHeader, toggleHeaderRow, toggleHeaderColumn} = require("../dist/")
 
 function test(doc, command, result) {
   let state = EditorState.create({doc, selection: selectionFor(doc)})
@@ -419,4 +419,28 @@ describe("toggleHeaderColumn", () => {
      test(doc(table(tr(hCursor, c11), tr(c11, c11))),
           toggleHeaderColumn,
           doc(table(tr(c11, c11), tr(c11, c11)))))
+})
+
+describe("toggleHeader", () => {
+  it("turns a header row with colspan and rowspan into a regular cell", () =>
+    test(doc(p('x'), table(tr(h(2, 1), h(1, 2)), tr(cCursor, c11), tr(c11, c11, c11))),
+         toggleHeader("row", { useDeprecateLogic: false }),
+         doc(p('x'), table(tr(c(2, 1), c(1, 2)), tr(cCursor, c11), tr(c11, c11, c11)))))
+
+  it("turns a header column with colspan and rowspan into a regular cell", () =>
+    test(doc(p('x'), table(tr(h(2, 1), h(1, 2)), tr(cCursor, c11), tr(c11, c11, c11))),
+         toggleHeader("column", { useDeprecateLogic: false }),
+         doc(p('x'), table(tr(h(2, 1), h(1, 2)), tr(h11, c11), tr(h11, c11, c11)))))
+
+  it("should keep first cell as header when the column header is enabled", () =>
+    test(doc(p('x'), table(tr(h11, c11), tr(hCursor, c11), tr(h11, c11))),
+         toggleHeader("row", { useDeprecateLogic: false }),
+         doc(p('x'), table(tr(h11, h11), tr(h11, c11), tr(h11, c11)))))
+
+  describe("new behavior", () => {
+    it("turns a header column into regular cells without override header row", () =>
+       test(doc(table(tr(hCursor, h11), tr(h11, c11))),
+            toggleHeader("column", { useDeprecateLogic: false }),
+            doc(table(tr(hCursor, h11), tr(c11, c11)))))
+  })
 })


### PR DESCRIPTION
The current implementation has a few bugs and a misunderstand on the implementation, this new logic will fix the bugs and bring a new approach about how we deal with toggleHeaders.

the current deprecated behavior:
![Screen Recording 2019-05-03 at 03 46 pm](https://user-images.githubusercontent.com/3452187/57121422-c3edd880-6dba-11e9-82f6-092c0a0cbfad.gif)


with the new logic `toggleHeader('column')` this is the result:
![Screen Recording 2019-05-03 at 03 49 pm](https://user-images.githubusercontent.com/3452187/57121469-1af3ad80-6dbb-11e9-9ee4-f299501b4ed6.gif)


For now we are keeping the functions `toggleHeaderRow,toggleHeaderColumn and toggleHeaderCell` using the deprecated logic, until next major release. To use the new logic you should you the `toggleHeader` directly.


# bugs solved with this new logic:

## 1 - merged cells and rows and toggle column header, table header is applied on wrong cells
| BEFORE        | AFTER           |
| ------------- |:-------------:| 
| ![Screen Recording 2019-05-03 at 03 55 pm](https://user-images.githubusercontent.com/3452187/57121593-fd731380-6dbb-11e9-9619-98b3dd5dff1a.gif) | ![Screen Recording 2019-05-03 at 03 54 pm](https://user-images.githubusercontent.com/3452187/57121598-049a2180-6dbc-11e9-8a0e-b688b18436b7.gif) |

## 2 - Cursor position is defining where we should apply the headers.
| BEFORE        | AFTER           |
| ------------- |:-------------:| 
|  ![Screen Recording 2019-05-03 at 03 58 pm](https://user-images.githubusercontent.com/3452187/57122190-66a85600-6dbf-11e9-869d-1196afbd5313.gif)| ![Screen Recording 2019-05-03 at 04 21 pm](https://user-images.githubusercontent.com/3452187/57122223-9b1c1200-6dbf-11e9-8d6b-54a2598881b6.gif) |
 