### PR TITLE
fix wrong column resizing handle insertion

### DIFF
--- a/src/columnresizing.js
+++ b/src/columnresizing.js
@@ -211,7 +211,7 @@ function handleDecorations(state, cell) {
     // of the table to their right, and either the top of the table or
     // a different cell above them, add a decoration
     if ((col == map.width || map.map[index] != map.map[index + 1]) &&
-        (row == 0 || map.map[index - 1] != map.map[index - 1 - map.width])) {
+        (row == 0 || map.map[index] != map.map[index - map.width])) {
       let cellPos = map.map[index]
       let pos = start + cellPos + table.nodeAt(cellPos).nodeSize - 1
       let dom = document.createElement("div")


### PR DESCRIPTION
This is what the above comments want.

Before this commit:

<img width="817" alt="스크린샷 2019-06-18 오후 11 25 18" src="https://user-images.githubusercontent.com/2945463/59692854-cbf5c080-9220-11e9-8bf7-1a1e7313da85.png">

After this commit:

<img width="819" alt="스크린샷 2019-06-18 오후 11 25 41" src="https://user-images.githubusercontent.com/2945463/59692864-d021de00-9220-11e9-8e01-47d6def6dc03.png">