### PR TITLE
Fix cell wrapping no checking in the current depth

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -13,7 +13,7 @@ export function cellAround($pos) {
 }
 
 export function cellWrapping($pos) {
-  for (let d = $pos.depth - 1; d > 0; d--) {
+  for (let d = $pos.depth; d > 0; d--) { // Sometimes the cell can be in the same depth.
     const role = $pos.node(d).type.spec.tableRole;
     if (role === "cell" || role === 'header_cell') return $pos.node(d)
   }


### PR DESCRIPTION
Fix bug where cannot split cells when the selection is in the same depth as the cell but it's not a cell selection.

I tried to add a test case into the suite, but it wasn't possible. I couldn't replicate the conditions that cause a selection to have the same depth as the cell. You can simulate this scenario in our storybook:  https://atlaskit.atlassian.com/examples/editor/editor-core/full-page 

Creating a table with a merged cell and trying to split the cell with a media or gap cursor inside the cell.