### PR TITLE
Add fixTables into index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -267,3 +267,8 @@ export function nextCell<S extends Schema = any>(
   axis: string,
   dir: number
 ): null | ResolvedPos<S>;
+
+export function fixTables<S extends Schema = any>(
+  state: EditorState<S>,
+  oldState?: EditorState<S>
+): null | Transaction<S>;


### PR DESCRIPTION
Function `fixTables` is export by `index.js`, by it's not included in `index.d.ts`. This PR fixes it.