### PR TITLE
Fix finicky resize handle

### DIFF
--- a/src/columnresizing.js
+++ b/src/columnresizing.js
@@ -72,9 +72,9 @@ function handleMouseMove(view, event, handleWidth, cellMinWidth, lastColumnResiz
     if (target) {
       let {left, right} = target.getBoundingClientRect()
       if (event.clientX - left <= handleWidth)
-        cell = edgeCell(view, event, "left")
+        cell = edgeCell(view, event, "left", handleWidth)
       else if (right - event.clientX <= handleWidth)
-        cell = edgeCell(view, event, "right")
+        cell = edgeCell(view, event, "right", handleWidth)
     }
 
     if (cell != pluginState.activeHandle) {
@@ -147,8 +147,12 @@ function domCellAround(target) {
   return target
 }
 
-function edgeCell(view, event, side) {
-  let {pos} = view.posAtCoords({left: event.clientX, top: event.clientY})
+function edgeCell(view, event, side, handleWidth) {
+  // posAtCoords returns inconsistent positions when cursor is moving
+  // across a collapsed table border. Use an offset to adjust the
+  // target viewport coordinates away from the table border.
+  let offset = side == "right" ? -handleWidth : handleWidth
+  let {pos} = view.posAtCoords({left: event.clientX + offset, top: event.clientY})
   let $cell = cellAround(view.state.doc.resolve(pos))
   if (!$cell) return -1
   if (side == "right") return $cell.pos


### PR DESCRIPTION
Picking up where @wes-r left off with https://github.com/ProseMirror/prosemirror-tables/pull/57. Looks like it was closed due to inactivity.

> In some cases `posAtCoords` was returning the wrong `pos`. This resulted in the drag handle jumping one column over. The fix is to add a buffer so that `posAtCoords` is not given a `left` value that is very much on the border between two cells.
> 
> BEFORE FIX (notice resize-handle jumps to the left):
>
> ![](https://user-images.githubusercontent.com/1568246/44891965-3ba9b780-acb0-11e8-9baf-bb96c6d71f68.gif)
> 
> AFTER FIX (smooth as butter):
> 
> ![](https://user-images.githubusercontent.com/1568246/44891941-20d74300-acb0-11e8-9fa4-9dc4c59d0b7b.gif)

