### PR TITLE
Export `setAttr`, `pointsAtCell`, `tableNodeTypes` and `TableView` at `index.js`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,12 +66,12 @@ export function tableEditing({ allowTableNodeSelection = false } = {}) {
 }
 
 export {fixTables, handlePaste, fixTablesKey}
-export {cellAround, isInTable, selectionCell, moveCellForward, inSameTable, findCell, colCount, nextCell} from "./util";
-export {tableNodes} from "./schema"
+export {cellAround, isInTable, selectionCell, moveCellForward, inSameTable, findCell, colCount, nextCell, setAttr, pointsAtCell} from "./util";
+export {tableNodes, tableNodeTypes} from "./schema"
 export {CellSelection} from "./cellselection"
 export {TableMap} from "./tablemap"
 export {tableEditingKey};
 export * from "./commands"
 export {columnResizing, key as columnResizingPluginKey} from "./columnresizing"
-export {updateColumns as updateColumnsOnResize} from "./tableview"
+export {updateColumns as updateColumnsOnResize, TableView} from "./tableview"
 export {pastedCells as __pastedCells, insertCells as __insertCells, clipCells as __clipCells} from "./copypaste"


### PR DESCRIPTION
Hi

My team and I are working on[ an editor](https://github.com/chanzuckerberg/czi-prosemirror) that has a different table-resizing behavior. In order to do that, we'd like to use some of the utility functions but unfortunately these function are not exported to `index.js` yet.

Our current workaround is to use a [forked version ](https://github.com/chanzuckerberg/prosemirror-tables/commits/add_export_v0_9_5) and that's not an ideal solution so we'd hope to merge the changes back to master then we'd continue to use the latest `prosemirror-table`.

Thanks.