### PR TITLE
Expose internal utils

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -271,6 +271,14 @@ export function cellAround<S extends Schema = any>(
 
 export function isInTable(state: EditorState): boolean;
 
+export function rmColSpan<T extends {}>(attrs: T, pos: number, n?: number):  T;
+export function addColSpan<T extends {}>(attrs: T, pos: number, n?: number):  T;
+
+type TableRoles = 'table' | 'row' | 'cell' | 'header_cell';
+
+export function columnIsHeader(map: TableMap, table: ProsemirrorNode, col: number): boolean;
+export function tableNodeTypes(schema: Schema): Record<TableRoles, NodeType>;
+
 export function selectionCell<S extends Schema = any>(
   state: EditorState<S>
 ): ResolvedPos<S> | null | undefined;

--- a/index.d.ts
+++ b/index.d.ts
@@ -271,7 +271,7 @@ export function cellAround<S extends Schema = any>(
 
 export function isInTable(state: EditorState): boolean;
 
-export function rmColSpan<T extends {}>(attrs: T, pos: number, n?: number):  T;
+export function removeColSpan<T extends {}>(attrs: T, pos: number, n?: number):  T;
 export function addColSpan<T extends {}>(attrs: T, pos: number, n?: number):  T;
 
 type TableRoles = 'table' | 'row' | 'cell' | 'header_cell';

--- a/src/cellselection.js
+++ b/src/cellselection.js
@@ -8,7 +8,7 @@ import {Decoration, DecorationSet} from "prosemirror-view"
 import {Fragment, Slice} from "prosemirror-model"
 
 
-import {inSameTable, pointsAtCell, setAttr, rmColSpan} from "./util"
+import {inSameTable, pointsAtCell, setAttr, removeColSpan} from "./util"
 import {TableMap} from "./tablemap"
 
 // ::- A [`Selection`](http://prosemirror.net/docs/ref/#state.Selection)
@@ -77,8 +77,8 @@ export class CellSelection extends Selection {
           let extraLeft = rect.left - cellRect.left, extraRight = cellRect.right - rect.right
           if (extraLeft > 0 || extraRight > 0) {
             let attrs = cell.attrs
-            if (extraLeft > 0) attrs = rmColSpan(attrs, 0, extraLeft)
-            if (extraRight > 0) attrs = rmColSpan(attrs, attrs.colspan - extraRight, extraRight)
+            if (extraLeft > 0) attrs = removeColSpan(attrs, 0, extraLeft)
+            if (extraRight > 0) attrs = removeColSpan(attrs, attrs.colspan - extraRight, extraRight)
             if (cellRect.left < rect.left) cell = cell.type.createAndFill(attrs)
             else cell = cell.type.create(attrs, cell.content)
           }

--- a/src/commands.js
+++ b/src/commands.js
@@ -3,11 +3,20 @@
 import {TextSelection} from "prosemirror-state"
 import {Fragment} from "prosemirror-model"
 
-import {TableMap, Rect} from "./tablemap"
+import {Rect, TableMap} from "./tablemap"
 import {CellSelection} from "./cellselection"
-import {setAttr, addColSpan, rmColSpan, moveCellForward, isInTable, selectionCell} from "./util"
+import {
+  addColSpan,
+  cellAround,
+  cellWrapping,
+  columnIsHeader,
+  isInTable,
+  moveCellForward,
+  rmColSpan,
+  selectionCell,
+  setAttr
+} from "./util"
 import {tableNodeTypes} from "./schema"
-import {cellWrapping, cellAround} from './util'
 
 // Helper to get the selected rectangle in a table, if any. Adds table
 // map, table node, and table start offset to the object for
@@ -24,14 +33,6 @@ export function selectedRect(state) {
   rect.map = map
   rect.table = table
   return rect
-}
-
-function columnIsHeader(map, table, col) {
-  let headerCell = tableNodeTypes(table.type.schema).header_cell
-  for (let row = 0; row < map.height; row++)
-    if (table.nodeAt(map.map[col + row * map.width]).type != headerCell)
-      return false
-  return true
 }
 
 // Add a column at the given position in a table.

--- a/src/commands.js
+++ b/src/commands.js
@@ -12,7 +12,7 @@ import {
   columnIsHeader,
   isInTable,
   moveCellForward,
-  rmColSpan,
+  removeColSpan,
   selectionCell,
   setAttr
 } from "./util"
@@ -89,7 +89,7 @@ export function removeColumn(tr, {map, table, tableStart}, col) {
     // If this is part of a col-spanning cell
     if ((col > 0 && map.map[index - 1] == pos) || (col < map.width - 1 && map.map[index + 1] == pos)) {
       tr.setNodeMarkup(tr.mapping.slice(mapStart).map(tableStart + pos), null,
-                       rmColSpan(cell.attrs, col - map.colCount(pos)))
+                       removeColSpan(cell.attrs, col - map.colCount(pos)))
     } else {
       let start = tr.mapping.slice(mapStart).map(tableStart + pos)
       tr.delete(start, start + cell.nodeSize)

--- a/src/copypaste.js
+++ b/src/copypaste.js
@@ -13,7 +13,7 @@
 import {Slice, Fragment} from "prosemirror-model"
 import {Transform} from "prosemirror-transform"
 
-import {setAttr, rmColSpan} from "./util"
+import {setAttr, removeColSpan} from "./util"
 import {TableMap} from "./tablemap"
 import {CellSelection} from "./cellselection"
 import {tableNodeTypes} from "./schema"
@@ -93,7 +93,7 @@ export function clipCells({width, height, rows}, newWidth, newHeight) {
       for (let col = added[row] || 0, i = 0; col < newWidth; i++) {
         let cell = frag.child(i % frag.childCount)
         if (col + cell.attrs.colspan > newWidth)
-          cell = cell.type.create(rmColSpan(cell.attrs, cell.attrs.colspan, col + cell.attrs.colspan - newWidth), cell.content)
+          cell = cell.type.create(removeColSpan(cell.attrs, cell.attrs.colspan, col + cell.attrs.colspan - newWidth), cell.content)
         cells.push(cell)
         col += cell.attrs.colspan
         for (let j = 1; j < cell.attrs.rowspan; j++)
@@ -191,8 +191,8 @@ function isolateVertical(tr, map, table, start, top, bottom, left, mapFrom) {
       found = true
       let cell = table.nodeAt(pos), cellLeft = map.colCount(pos)
       let updatePos = tr.mapping.slice(mapFrom).map(pos + start)
-      tr.setNodeMarkup(updatePos, null, rmColSpan(cell.attrs, left - cellLeft, cell.attrs.colspan - (left - cellLeft)))
-      tr.insert(updatePos + cell.nodeSize, cell.type.createAndFill(rmColSpan(cell.attrs, 0, left - cellLeft)))
+      tr.setNodeMarkup(updatePos, null, removeColSpan(cell.attrs, left - cellLeft, cell.attrs.colspan - (left - cellLeft)))
+      tr.insert(updatePos + cell.nodeSize, cell.type.createAndFill(removeColSpan(cell.attrs, 0, left - cellLeft)))
       row += cell.attrs.rowspan - 1
     }
   }

--- a/src/fixtables.js
+++ b/src/fixtables.js
@@ -5,7 +5,7 @@
 
 import {PluginKey} from "prosemirror-state"
 import {TableMap} from "./tablemap"
-import {setAttr, rmColSpan} from "./util"
+import {setAttr, removeColSpan} from "./util"
 import {tableNodeTypes} from "./schema"
 import {key} from "./util"
 
@@ -66,7 +66,7 @@ export function fixTable(state, table, tablePos, tr) {
     if (prob.type == "collision") {
       let cell = table.nodeAt(prob.pos)
       for (let j = 0; j < cell.attrs.rowspan; j++) mustAdd[prob.row + j] += prob.n
-      tr.setNodeMarkup(tr.mapping.map(tablePos + 1 + prob.pos), null, rmColSpan(cell.attrs, cell.attrs.colspan - prob.n, prob.n))
+      tr.setNodeMarkup(tr.mapping.map(tablePos + 1 + prob.pos), null, removeColSpan(cell.attrs, cell.attrs.colspan - prob.n, prob.n))
     } else if (prob.type == "missing") {
       mustAdd[prob.row] += prob.n
     } else if (prob.type == "overlong_rowspan") {

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ export function tableEditing({ allowTableNodeSelection = false } = {}) {
 }
 
 export {fixTables, handlePaste, fixTablesKey}
-export {cellAround, isInTable, selectionCell, moveCellForward, inSameTable, findCell, colCount, nextCell, setAttr, pointsAtCell, rmColSpan, addColSpan, columnIsHeader} from "./util";
+export {cellAround, isInTable, selectionCell, moveCellForward, inSameTable, findCell, colCount, nextCell, setAttr, pointsAtCell, removeColSpan, addColSpan, columnIsHeader} from "./util";
 export {tableNodes, tableNodeTypes} from "./schema"
 export {CellSelection} from "./cellselection"
 export {TableMap} from "./tablemap"

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ export function tableEditing({ allowTableNodeSelection = false } = {}) {
 }
 
 export {fixTables, handlePaste, fixTablesKey}
-export {cellAround, isInTable, selectionCell, moveCellForward, inSameTable, findCell, colCount, nextCell, setAttr, pointsAtCell} from "./util";
+export {cellAround, isInTable, selectionCell, moveCellForward, inSameTable, findCell, colCount, nextCell, setAttr, pointsAtCell, rmColSpan, addColSpan, columnIsHeader} from "./util";
 export {tableNodes, tableNodeTypes} from "./schema"
 export {CellSelection} from "./cellselection"
 export {TableMap} from "./tablemap"

--- a/src/util.js
+++ b/src/util.js
@@ -3,6 +3,7 @@
 import {PluginKey} from "prosemirror-state"
 
 import {TableMap} from "./tablemap"
+import {tableNodeTypes} from "./schema";
 
 export const key = new PluginKey("selectingCells")
 
@@ -97,4 +98,12 @@ export function addColSpan(attrs, pos, n=1) {
     for (let i = 0; i < n; i++) result.colwidth.splice(pos, 0, 0)
   }
   return result
+}
+
+export function columnIsHeader(map, table, col) {
+  let headerCell = tableNodeTypes(table.type.schema).header_cell
+  for (let row = 0; row < map.height; row++)
+    if (table.nodeAt(map.map[col + row * map.width]).type != headerCell)
+      return false
+  return true
 }

--- a/src/util.js
+++ b/src/util.js
@@ -81,7 +81,7 @@ export function setAttr(attrs, name, value) {
   return result
 }
 
-export function rmColSpan(attrs, pos, n=1) {
+export function removeColSpan(attrs, pos, n=1) {
   let result = setAttr(attrs, "colspan", attrs.colspan - n)
   if (result.colwidth) {
     result.colwidth = result.colwidth.slice()


### PR DESCRIPTION
I need to expose some internal utils. I required this to implement an iterator to get information of cells in a column:

```typescript
function cellsAtColumn*(rect: TableRect, col: number): Iterable<{
  row: number,
  from: number,
  to: number,
  hasMergedCells: boolean,
  type: NodeType,
 //......
}>
```

### Why an iterator?
For big tables iterate twice to do an operation will be expensive. An iterator allows you to use the same loop to do your own logic.

### Why don't we implement and export the iterator?
The project has a restriction about using iterators, I guess we don't want to drop support on older browsers.