### PR TITLE
Fix cursor retains selection mod

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -112,7 +112,11 @@ export function handlePaste(view, _, slice) {
 }
 
 export function handleMouseDown(view, startEvent) {
-  if (startEvent.ctrlKey || startEvent.metaKey) return
+  if (startEvent.ctrlKey || 
+      startEvent.metaKey || 
+      startEvent.which !== 1 /*not left click*/) {
+    return;
+  }
 
   let startDOMCell = domInCell(view, startEvent.target), $anchor
   if (startEvent.shiftKey && (view.state.selection instanceof CellSelection)) {


### PR DESCRIPTION
This fix the issue where after right clicking, cursor retains selection mode (you can see it selecting other cells until you press Esc), see attached video
![output](https://user-images.githubusercontent.com/50408095/82979373-3ff03980-a02a-11ea-9f17-62fc7f11b23c.gif)

Step to reproduce this issue:
1. Use shift + click to select multiple cells
2. Right click to copy
3. Move your cursor
Notice that selection mode is retained.
