### PR TITLE
Fix clipCells to avoid negative rowSpan

### DIFF
--- a/src/copypaste.js
+++ b/src/copypaste.js
@@ -112,7 +112,7 @@ export function clipCells({width, height, rows}, newWidth, newHeight) {
       for (let j = 0; j < source.childCount; j++) {
         let cell = source.child(j)
         if (row + cell.attrs.rowspan > newHeight)
-          cell = cell.type.create(setAttr(cell.attrs, "rowspan", newHeight - cell.attrs.rowspan), cell.content)
+          cell = cell.type.create(setAttr(cell.attrs, "rowspan", Math.max(1, newHeight - cell.attrs.rowspan)), cell.content)
         cells.push(cell)
       }
       newRows.push(Fragment.from(cells))

--- a/test/test-copypaste.js
+++ b/test/test-copypaste.js
@@ -80,6 +80,10 @@ describe("clipCells", () => {
   it("clips off excess rowspan", () =>
      test(table("<a>", tr(c(2, 2), c11), tr(c11), "<b>"),
           2, 3, [[c(2, 2)], [], [c(2, 1)]]))
+
+  it("clips off excess rowspan when new table height is bigger than the current table height", () =>  
+     test(table("<a>", tr(c(1, 2), c(2, 1)), tr(c11, c11), "<b>"),
+          3, 1, [[c(1, 1), c(2, 1)]]))
 })
 
 describe("insertCells", () => {


### PR DESCRIPTION
There's a use case where `prosemirror-tables` produce a negative rowSpan on paste that breaks the whole page in Confluence. 

Steps to reproduce: 
1. in the table below, copy the first two rows
2. select the last row and paste the copied slice

<img width="803" alt="Screen Shot 2020-07-29 at 11 46 54 am" src="https://user-images.githubusercontent.com/26512812/88747018-436e8100-d191-11ea-9fe4-0ed5514dd455.png">

This happens inside `handlePaste` that calls `clipCells`. We're simply adding a check to avoid negative rowSpans.