### PR TITLE
Add instructions for tableEditing plugin CSS to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ schema. That's what `tableNodes` is for:
    Creates a [plugin](http://prosemirror.net/docs/ref/#state.Plugin)
    that, when added to an editor, enables cell-selection, handles
    cell-based copy/paste, and makes sure tables stay well-formed (each
-   row has the same width, and cells don't overlap).
+   row has the same width, and cells don't overlap). Make sure you load 
+   `style/tables.css` (or define your own styling for the tables).
 
    You should probably put this plugin near the end of your array of
    plugins, since it handles mouse and arrow key events in tables


### PR DESCRIPTION
This adds instructions for using the table styles provided with the `tableEditing` plugin, adapting the wording from the similar instructions in [prosemirror-gapcursor](https://github.com/ProseMirror/prosemirror-gapcursor) (feel free to edit).