### PR TITLE
fix(types): let CellSelection extends Selection

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,7 +58,7 @@ export interface CellSelectionJSON {
   head: number;
 }
 
-export class CellSelection<S extends Schema = any> {
+export class CellSelection<S extends Schema = any> extends Selection<S> {
   constructor($anchorCell: ResolvedPos<S>, $headCell?: ResolvedPos<S>);
 
   from: number;
@@ -83,7 +83,6 @@ export class CellSelection<S extends Schema = any> {
   isColSelection(): boolean;
   eq(other: Selection<S>): boolean;
   toJSON(): CellSelectionJSON;
-  getBookmark(): { anchor: number; head: number };
 
   static colSelection<S extends Schema = any>(
     anchorCell: ResolvedPos<S>,


### PR DESCRIPTION
Based on the document and the JS implementation, `CellSelection` is a subclass of `Selection`. This PR let `CellSelection` extends `Selection` in `index.d.ts`. More specifically, this PR fixes two type errors in `CellSelection`:

1. `CellSelection` doesn't define property `visible`, which is defined in `Selection`.
2. `CellSelection` doesn't provide the same definition for `getBookmark` as `Selection`'s.