### PR TITLE
fix removeRow mistake: (row < map.width) -> (row < map.height)

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -183,7 +183,7 @@ export function removeRow(tr, {map, table, tableStart}, row) {
       let attrs = table.nodeAt(pos).attrs
       tr.setNodeMarkup(tr.mapping.slice(mapFrom).map(pos + tableStart), null, setAttr(attrs, "rowspan", attrs.rowspan - 1))
       col += attrs.colspan - 1
-    } else if (row < map.width && pos == map.map[index + map.width]) {
+    } else if (row < map.height && pos == map.map[index + map.width]) {
       // Else, if it continues in the row below, it has to be moved down
       let cell = table.nodeAt(pos)
       let copy = cell.type.create(setAttr(cell.attrs, "rowspan", cell.attrs.rowspan - 1), cell.content)


### PR DESCRIPTION

### Before delete row
![image](https://user-images.githubusercontent.com/17960084/110600341-cbecdf80-81be-11eb-8b05-141049ff13fc.png)

### After delete row
![image](https://user-images.githubusercontent.com/17960084/110600488-f179e900-81be-11eb-842f-ee1426e53ca3.png)

this condition is checked merged cell in next line, so it should be `row < map.height`
when we fixed it：
![image](https://user-images.githubusercontent.com/17960084/110601146-98f71b80-81bf-11eb-93f1-ef984bcd6af5.png)

