### PR TITLE
Update columnresizing.js

### DIFF
--- a/src/columnresizing.js
+++ b/src/columnresizing.js
@@ -142,7 +142,7 @@ function currentColWidth(view, cellPos, {colspan, colwidth}) {
 }
 
 function domCellAround(target) {
-  while (target && target.nodeName != "TD" && target.nodeName != "TH")
+  while (target && target.classList && target.nodeName != "TD" && target.nodeName != "TH")
     target = target.classList.contains("ProseMirror") ? null : target.parentNode
   return target
 }


### PR DESCRIPTION
Add check to ensure classList property is present on target before attempting to use it. Otherwise, this line throws an error when target does not have a classList property (possible with custom nodeViews).
![Screen Shot 2021-05-05 at 5 54 52 PM](https://user-images.githubusercontent.com/54816859/117227151-0ba10380-adcb-11eb-864f-4deeb7a578c8.png)
