### PR TITLE
fix that addColumn adding a table_cell node when a table has only one row that consists of table_header nodes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ import {
   Schema,
   NodeType
 } from 'prosemirror-model';
-import { Mappable } from 'prosemirror-transform';
+import { Mappable, Mapping } from 'prosemirror-transform';
 import { NodeView } from 'prosemirror-view';
 
 export interface TableEditingOptions {
@@ -83,7 +83,7 @@ export class CellSelection<S extends Schema = any> extends Selection<S> {
   isColSelection(): boolean;
   eq(other: Selection<S>): boolean;
   toJSON(): CellSelectionJSON;
-  getBookmark(): { anchor: number; head: number };
+  getBookmark(): CellBookmark;
 
   static colSelection<S extends Schema = any>(
     anchorCell: ResolvedPos<S>,
@@ -131,6 +131,13 @@ export class TableMap {
   positionAt(row: number, col: number, table: ProsemirrorNode): number;
 
   static get(table: ProsemirrorNode): TableMap;
+}
+
+export interface CellBookmark<S extends Schema = any> {
+  anchor: number
+  head: number
+  map(mapping: Mapping): CellBookmark<S>;
+  resolve(doc: ProsemirrorNode<S>): Selection<S>;
 }
 
 export function tableEditing(options?: TableEditingOptions): Plugin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,7 +58,7 @@ export interface CellSelectionJSON {
   head: number;
 }
 
-export class CellSelection<S extends Schema = any> {
+export class CellSelection<S extends Schema = any> extends Selection<S> {
   constructor($anchorCell: ResolvedPos<S>, $headCell?: ResolvedPos<S>);
 
   from: number;

--- a/src/commands.js
+++ b/src/commands.js
@@ -38,7 +38,7 @@ export function selectedRect(state) {
 // Add a column at the given position in a table.
 export function addColumn(tr, {map, tableStart, table}, col) {
   let refColumn = col > 0 ? -1 : 0
-  if (columnIsHeader(map, table, col + refColumn))
+  if (map.height > 1 && columnIsHeader(map, table, col + refColumn))
     refColumn = col == 0 || col == map.width ? null : 0
 
   for (let row = 0; row < map.height; row++) {

--- a/test/test-commands.js
+++ b/test/test-commands.js
@@ -28,6 +28,11 @@ describe("addColumnAfter", () => {
           addColumnAfter,
           table(tr(c11, cEmpty))))
 
+  it("can add a second header cell", () =>
+     test(table(tr(hCursor)),
+          addColumnAfter,
+          table(tr(h11, hEmpty))));
+
   it("can grow a colspan cell", () =>
      test(table(tr(cCursor, c11), tr(c(2, 1))),
           addColumnAfter,


### PR DESCRIPTION
closes #125
