### PR TITLE
Add types for pointsAtCell, setAttrs, TableView

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -268,6 +268,11 @@ export function cellAround(pos: ResolvedPos): ResolvedPos | null;
 
 export function isInTable(state: EditorState): boolean;
 export function pointsAtCell($pos: ResolvedPos): false | null | ProsemirrorNode;
+export function setAttr<T extends any>(
+  attrs: Record<string, T>,
+  name: string,
+  value: T,
+): Record<string, T>;
 
 export function removeColSpan<T extends {}>(
   attrs: T,

--- a/index.d.ts
+++ b/index.d.ts
@@ -264,6 +264,13 @@ export function updateColumnsOnResize(
   overrideValue?: number,
 ): void;
 
+export class TableView {
+  constructor(node: ProsemirrorNode, cellMinWidth: number);
+
+  update: (node: Node) => boolean;
+  ignoreMutation: (mutation: MutationRecord) => boolean;
+}
+
 export function cellAround(pos: ResolvedPos): ResolvedPos | null;
 
 export function isInTable(state: EditorState): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -267,6 +267,7 @@ export function updateColumnsOnResize(
 export function cellAround(pos: ResolvedPos): ResolvedPos | null;
 
 export function isInTable(state: EditorState): boolean;
+export function pointsAtCell($pos: ResolvedPos): false | null | ProsemirrorNode;
 
 export function removeColSpan<T extends {}>(
   attrs: T,


### PR DESCRIPTION
Closes https://github.com/ProseMirror/prosemirror-tables/issues/164
Closes https://github.com/ProseMirror/prosemirror-tables/issues/140
Closes https://github.com/ProseMirror/prosemirror-tables/issues/133
Closes https://github.com/ProseMirror/prosemirror-tables/issues/124

I know this is a duplicate of this one: https://github.com/ProseMirror/prosemirror-tables/pull/131, but I create a PR because I incorporated the latest upstream.