### PR TITLE
fix typings test is not worked

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,6 @@
   },
   "parserOptions": {
     "sourceType": "module",
-    "ecmaVersion": 2017
+    "ecmaVersion": 2020
   }
 }

--- a/test/test-typescript.js
+++ b/test/test-typescript.js
@@ -1,9 +1,11 @@
 import { checkDirectory } from 'typings-tester';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 describe('TypeScript definitions', function () {
   it('should compile against index.d.ts', () => {
-    const __dirname = path.resolve();
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
     checkDirectory(__dirname + '/typescript');
   });
 });


### PR DESCRIPTION
Currently, errors of the type that should fail are also green.

The result of `path.resolve()` changed here commit https://github.com/ProseMirror/prosemirror-tables/commit/49acc2dbc3d1bd030e885dc6615ae461e665add6 was the root directory, because of the directory where the node process runs.
By using import.meta.url, the correct path can be specified independent of the execution location.