### PR TITLE
fix CellBookmark typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ import {
   Schema,
   NodeType,
 } from 'prosemirror-model';
-import { Mappable, Mapping } from 'prosemirror-transform';
+import { Mappable } from 'prosemirror-transform';
 import { EditorView, NodeView } from 'prosemirror-view';
 
 export interface TableEditingOptions {
@@ -126,7 +126,7 @@ export class TableMap {
 export interface CellBookmark {
   anchor: number;
   head: number;
-  map(mapping: Mapping): CellBookmark;
+  map(mapping: Mappable): CellBookmark;
   resolve(doc: ProsemirrorNode): Selection;
 }
 

--- a/test/typescript/prosemirror-tables.ts
+++ b/test/typescript/prosemirror-tables.ts
@@ -1,5 +1,12 @@
-import { TableMap, toggleHeader, TableRect, tableEditing } from '../../';
+import {
+  TableMap,
+  toggleHeader,
+  TableRect,
+  tableEditing,
+  CellSelection,
+} from '../../';
 import { Node as ProsemirrorNode } from 'prosemirror-model';
+import { EditorState } from 'prosemirror-state';
 
 const tableEditing1 = tableEditing();
 const tableWithNodeSelection = tableEditing({ allowTableNodeSelection: true });
@@ -21,3 +28,8 @@ const tableRect: TableRect = {
   map,
   table,
 };
+
+EditorState.create({
+  doc: table,
+  selection: CellSelection.create(table, 0),
+});


### PR DESCRIPTION
https://github.com/ProseMirror/prosemirror-tables/pull/160
The CellBookmark type added here was incorrect and the following error is fixed.

```
index.ts:25:43 - error TS2322: Type 'CellSelection' is not assignable to type 'Selection'.
  The types of 'getBookmark().map' are incompatible between these types.
    Type '(mapping: Mapping) => CellBookmark' is not assignable to type '(mapping: Mappable) => SelectionBookmark'.
      Types of parameters 'mapping' and 'mapping' are incompatible.
        Type 'Mappable' is missing the following properties from type 'Mapping': maps, from, to, slice, and 5 more.

1      let state = EditorState.create({ doc, selection: CellSelection.create(table, 0) });
```