### PR TITLE
Make typescript test stricter

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     "rollup": "^2.74.1",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "typescript": "^4.0.0",
-    "typings-tester": "^0.3.2"
+    "typescript": "^4.0.0"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/test/test-typescript.js
+++ b/test/test-typescript.js
@@ -1,9 +1,0 @@
-import { checkDirectory } from 'typings-tester';
-import path from 'path';
-
-describe('TypeScript definitions', function () {
-  it('should compile against index.d.ts', () => {
-    const __dirname = path.resolve();
-    checkDirectory(__dirname + '/typescript');
-  });
-});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "baseUrl": "../",
     "typeRoots": ["../"],
     "types": [],
+    "strict": true,
     "noEmit": true
   },
   "files": ["index.d.ts", "test/typescript/prosemirror-tables.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -323,11 +323,6 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-commander@^2.12.2:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1425,13 +1420,6 @@ typescript@^4.0.0, typescript@^4.6.3:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
-
-typings-tester@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/typings-tester/-/typings-tester-0.3.2.tgz#04cc499d15ab1d8b2d14dd48415a13d01333bc5b"
-  integrity sha512-HjGoAM2UoGhmSKKy23TYEKkxlphdJFdix5VvqWFLzH1BJVnnwG38tpC6SXPgqhfFGfHY77RlN1K8ts0dbWBQ7A==
-  dependencies:
-    commander "^2.12.2"
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
There is a [TS issue](https://github.com/ProseMirror/prosemirror-tables/pull/178) in the latest version, which didn't get caught by the CI pipeline. More detail: #178 


The direct reason is that `typings-tester` was not configured correctly (#177). However, `typings-tester` doesn't get any new version since 4 years ago. I don't want to use an unmaintained pacakge so I remove it in this PR.

By adding `strict: true` in `tsconfig.json`, we can use `yarn typecheck` to find out the TS issue. So we don't need `typings-tester` anyway. 