### PR TITLE
Fix column resize handle logic

### DIFF
--- a/src/columnresizing.ts
+++ b/src/columnresizing.ts
@@ -365,12 +365,12 @@ export function handleDecorations(
   const col = map.colCount($cell.pos - start) + $cell.nodeAfter!.attrs.colspan;
   for (let row = 0; row < map.height; row++) {
     const index = col + row * map.width - 1;
-    // For positions that are have either a different cell or the end
+    // For positions that have either a different cell or the end
     // of the table to their right, and either the top of the table or
     // a different cell above them, add a decoration
     if (
       (col == map.width || map.map[index] != map.map[index + 1]) &&
-      (row == 0 || map.map[index - 1] != map.map[index - 1 - map.width])
+      (row == 0 || map.map[index] != map.map[index - map.width])
     ) {
       const cellPos = map.map[index];
       const pos = start + cellPos + table.nodeAt(cellPos)!.nodeSize - 1;


### PR DESCRIPTION
I am pretty sure this logic was incorrect, and it was causing the column drag resize handle to be missing from an edge when a cell two over to the left was vertically merged.

Before the change:

![before-resize](https://github.com/ProseMirror/prosemirror-tables/assets/6373939/d08a8d1e-6089-4b21-8880-d2b414bec477)

After the change:
![after-resize](https://github.com/ProseMirror/prosemirror-tables/assets/6373939/5a2bd3d4-5228-4b42-a3e6-17e94ac5d77c)
