### PR TITLE
Fix tableEditing arrows keymap when table cell content is inline instead of block or paragraph

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -271,6 +271,11 @@ export function handleMouseDown(
 function atEndOfCell(view: EditorView, axis: Axis, dir: number): null | number {
   if (!(view.state.selection instanceof TextSelection)) return null;
   const { $head } = view.state.selection;
+  if ($head.parent.type.spec.tableRole == "cell" || $head.parent.type.spec.tableRole == "header_cell") {
+    const cellPos = $head.before();
+    const dirStr = axis == "vert" ? dir > 0 ? "down" : "up" : dir > 0 ? "right" : "left";
+    return view.endOfTextblock(dirStr) ? cellPos : null;
+  }
   for (let d = $head.depth - 1; d >= 0; d--) {
     const parent = $head.node(d),
       index = dir < 0 ? $head.index(d) : $head.indexAfter(d);


### PR DESCRIPTION
When you redefine the table cell and headers to have `inline*` for content instead of `block+`, the keymap added by `tableEditing` didn't handle that correctly, this adds handling for that case to `atEndOfCell`.