### PR TITLE
Fix deleteRow for cells with colspan greater than 1

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -288,20 +288,22 @@ export function removeRow(
   row: number,
 ): void {
   let rowPos = 0;
-  const seen: Record<number, boolean> = {};
   for (let i = 0; i < row; i++) rowPos += table.child(i).nodeSize;
   const nextRow = rowPos + table.child(row).nodeSize;
 
   const mapFrom = tr.mapping.maps.length;
   tr.delete(rowPos + tableStart, nextRow + tableStart);
 
+  const seen = new Set<number>();
+
   for (let col = 0, index = row * map.width; col < map.width; col++, index++) {
     const pos = map.map[index];
+
+    // Skip cells that are checked already
+    if (seen.has(pos)) continue;
+    seen.add(pos);
+
     if (row > 0 && pos == map.map[index - map.width]) {
-      if (seen[pos]) { 
-        continue;
-      }
-      seen[pos] = true;
       // If this cell starts in the row above, simply reduce its rowspan
       const attrs = table.nodeAt(pos)!.attrs as CellAttrs;
       tr.setNodeMarkup(tr.mapping.slice(mapFrom).map(pos + tableStart), null, {
@@ -310,10 +312,6 @@ export function removeRow(
       });
       col += attrs.colspan - 1;
     } else if (row < map.width && pos == map.map[index + map.width]) {
-      if (seen[pos]) { 
-        continue;
-      }
-      seen[pos] = true;
       // Else, if it continues in the row below, it has to be moved down
       const cell = table.nodeAt(pos)!;
       const attrs = cell.attrs as CellAttrs;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -288,6 +288,7 @@ export function removeRow(
   row: number,
 ): void {
   let rowPos = 0;
+  const seen: Record<number, boolean> = {};
   for (let i = 0; i < row; i++) rowPos += table.child(i).nodeSize;
   const nextRow = rowPos + table.child(row).nodeSize;
 
@@ -297,6 +298,10 @@ export function removeRow(
   for (let col = 0, index = row * map.width; col < map.width; col++, index++) {
     const pos = map.map[index];
     if (row > 0 && pos == map.map[index - map.width]) {
+      if (seen[pos]) { 
+        continue;
+      }
+      seen[pos] = true;
       // If this cell starts in the row above, simply reduce its rowspan
       const attrs = table.nodeAt(pos)!.attrs as CellAttrs;
       tr.setNodeMarkup(tr.mapping.slice(mapFrom).map(pos + tableStart), null, {
@@ -305,6 +310,10 @@ export function removeRow(
       });
       col += attrs.colspan - 1;
     } else if (row < map.width && pos == map.map[index + map.width]) {
+      if (seen[pos]) { 
+        continue;
+      }
+      seen[pos] = true;
       // Else, if it continues in the row below, it has to be moved down
       const cell = table.nodeAt(pos)!;
       const attrs = cell.attrs as CellAttrs;

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -425,7 +425,7 @@ describe('deleteRow', () => {
       table(tr(c11, cEmpty)),
     ));
 
-  it('moves the same cell with colspan gt 1 that start in the deleted row only once', () =>
+  it('moves the same cell with colspan greater than 1 that start in the deleted row only once', () =>
     test(
       table(tr(c(3, 2), c11, c(2, 2), cCursor), tr(c11, cEmpty)),
       deleteRow,
@@ -444,7 +444,7 @@ describe('deleteRow', () => {
       table(tr(c11, c11)),
     ));
 
-  it('moves the same cell with colspan gt 1 that start in the deleted row only once when deleting multiple rows', () =>
+  it('moves the same cell with colspan greater than 1 that start in the deleted row only once when deleting multiple rows', () =>
     test(
       table(
         tr(c(2, 4), td({ rowspan: 3 }, p('<cursor>')), c11),

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -425,6 +425,13 @@ describe('deleteRow', () => {
       table(tr(c11, cEmpty)),
     ));
 
+  it('moves the same cell with colspan gt 1 that start in the deleted row only once', () =>
+    test(
+      table(tr(c(3, 2), c11, c(2, 2), cCursor), tr(c11, cEmpty)),
+      deleteRow,
+      table(tr(c(3, 1), c11, c(2, 1), cEmpty)),
+    ));
+
   it('deletes multiple rows when the start cell has a rowspan', () =>
     test(
       table(
@@ -435,6 +442,18 @@ describe('deleteRow', () => {
       ),
       deleteRow,
       table(tr(c11, c11)),
+    ));
+
+  it('moves the same cell with colspan gt 1 that start in the deleted row only once when deleting multiple rows', () =>
+    test(
+      table(
+        tr(c(2, 4), td({ rowspan: 3 }, p('<cursor>')), c11),
+        tr(c11),
+        tr(c11),
+        tr(c11, c11),
+      ),
+      deleteRow,
+      table(tr(c(2, 1), c11, c11)),
     ));
 
   it('skips columns when adjusting rowspan', () =>


### PR DESCRIPTION
### The original table 
![image](https://github.com/ProseMirror/prosemirror-tables/assets/35447076/85f95a43-d2a4-4816-80ca-94825a129aad)

### The table after deleting a row
![image](https://github.com/ProseMirror/prosemirror-tables/assets/35447076/9fb7ca4b-93ee-405e-824c-43d421cad328)
the cell whose colspan  is 2 marked in the green box is inserted twice.
In this commit, I added a variable "seen" to the function removeRow to skip the cells have been processed