### PR TITLE
Replace firstChild with firstElementChild

### DIFF
--- a/src/tableview.ts
+++ b/src/tableview.ts
@@ -48,7 +48,7 @@ export function updateColumnsOnResize(
 ): void {
   let totalWidth = 0;
   let fixedWidth = true;
-  let nextDOM = colgroup.firstChild as HTMLElement;
+  let nextDOM = colgroup.firstElementChild as HTMLElement;
   const row = node.firstChild;
   if (!row) return;
 


### PR DESCRIPTION
**Issue**:
In certain cases, `firstChild` returns a textNode due to whitespace or other content. This causes the resize functionality to break, as it expects an element node.

**Solution:**
To resolve this, I've replaced `firstChild` with `firstElementChild`. This ensures that the resize logic always interacts with a valid element node, preventing breaks in cases where firstChild returns a textNode.

issue in tiptap: ueberdosis/tiptap#5695