### PR TITLE
feat: add new option `defaultCellMinWidth` for `columnResizing()`

### DIFF
--- a/src/columnresizing.ts
+++ b/src/columnresizing.ts
@@ -27,9 +27,9 @@ export type ColumnResizingOptions = {
    * Minimum width of a cell /column. The column cannot be resized smaller than this.
    */
   cellMinWidth?: number;
-/**
- * The default minWidth of a cell / column when it doesn't have an explicit width (i.e.: it has not been resized manually)
- */
+  /**
+   * The default minWidth of a cell / column when it doesn't have an explicit width (i.e.: it has not been resized manually)
+   */
   defaultCellMinWidth?: number;
   lastColumnResizable?: boolean;
   /**
@@ -88,12 +88,7 @@ export function columnResizing({
 
       handleDOMEvents: {
         mousemove: (view, event) => {
-          handleMouseMove(
-            view,
-            event,
-            handleWidth,
-            lastColumnResizable,
-          );
+          handleMouseMove(view, event, handleWidth, lastColumnResizable);
         },
         mouseleave: (view) => {
           handleMouseLeave(view);
@@ -230,7 +225,12 @@ function handleMouseDown(
     if (!pluginState) return;
     if (pluginState.dragging) {
       const dragged = draggedWidth(pluginState.dragging, event, cellMinWidth);
-      displayColumnWidth(view, pluginState.activeHandle, dragged, defaultCellMinWidth);
+      displayColumnWidth(
+        view,
+        pluginState.activeHandle,
+        dragged,
+        defaultCellMinWidth,
+      );
     }
   }
 

--- a/src/tableview.ts
+++ b/src/tableview.ts
@@ -61,10 +61,15 @@ export function updateColumnsOnResize(
       totalWidth += hasWidth || cellMinWidth;
       if (!hasWidth) fixedWidth = false;
       if (!nextDOM) {
-        colgroup.appendChild(document.createElement('col')).style.width =
-          cssWidth;
+        const col = document.createElement('col');
+        col.style.width = cssWidth;
+        col.style.minWidth = cssWidth.length ? '' : cellMinWidth + 'px';
+        colgroup.appendChild(col);
       } else {
-        if (nextDOM.style.width != cssWidth) nextDOM.style.width = cssWidth;
+        if (nextDOM.style.width != cssWidth) {
+          nextDOM.style.width = cssWidth;
+          nextDOM.style.minWidth = cssWidth.length ? '' : cellMinWidth + 'px';
+        }
         nextDOM = nextDOM.nextSibling as HTMLElement;
       }
     }

--- a/src/tableview.ts
+++ b/src/tableview.ts
@@ -11,19 +11,19 @@ export class TableView implements NodeView {
   public colgroup: HTMLTableColElement;
   public contentDOM: HTMLTableSectionElement;
 
-  constructor(public node: Node, public cellMinWidth: number) {
+  constructor(public node: Node, public defaultCellMinWidth: number) {
     this.dom = document.createElement('div');
     this.dom.className = 'tableWrapper';
     this.table = this.dom.appendChild(document.createElement('table'));
     this.colgroup = this.table.appendChild(document.createElement('colgroup'));
-    updateColumnsOnResize(node, this.colgroup, this.table, cellMinWidth);
+    updateColumnsOnResize(node, this.colgroup, this.table, defaultCellMinWidth);
     this.contentDOM = this.table.appendChild(document.createElement('tbody'));
   }
 
   update(node: Node): boolean {
     if (node.type != this.node.type) return false;
     this.node = node;
-    updateColumnsOnResize(node, this.colgroup, this.table, this.cellMinWidth);
+    updateColumnsOnResize(node, this.colgroup, this.table, this.defaultCellMinWidth);
     return true;
   }
 
@@ -42,7 +42,7 @@ export function updateColumnsOnResize(
   node: Node,
   colgroup: HTMLTableColElement,
   table: HTMLTableElement,
-  cellMinWidth: number,
+  defaultCellMinWidth: number,
   overrideCol?: number,
   overrideValue?: number,
 ): void {
@@ -58,17 +58,17 @@ export function updateColumnsOnResize(
       const hasWidth =
         overrideCol == col ? overrideValue : colwidth && colwidth[j];
       const cssWidth = hasWidth ? hasWidth + 'px' : '';
-      totalWidth += hasWidth || cellMinWidth;
+      totalWidth += hasWidth || defaultCellMinWidth;
       if (!hasWidth) fixedWidth = false;
       if (!nextDOM) {
         const col = document.createElement('col');
         col.style.width = cssWidth;
-        col.style.minWidth = cssWidth.length ? '' : cellMinWidth + 'px';
+        col.style.minWidth = cssWidth.length ? '' : defaultCellMinWidth + 'px';
         colgroup.appendChild(col);
       } else {
         if (nextDOM.style.width != cssWidth) {
           nextDOM.style.width = cssWidth;
-          nextDOM.style.minWidth = cssWidth.length ? '' : cellMinWidth + 'px';
+          nextDOM.style.minWidth = cssWidth.length ? '' : defaultCellMinWidth + 'px';
         }
         nextDOM = nextDOM.nextSibling as HTMLElement;
       }

--- a/src/tableview.ts
+++ b/src/tableview.ts
@@ -23,7 +23,12 @@ export class TableView implements NodeView {
   update(node: Node): boolean {
     if (node.type != this.node.type) return false;
     this.node = node;
-    updateColumnsOnResize(node, this.colgroup, this.table, this.defaultCellMinWidth);
+    updateColumnsOnResize(
+      node,
+      this.colgroup,
+      this.table,
+      this.defaultCellMinWidth,
+    );
     return true;
   }
 
@@ -68,7 +73,9 @@ export function updateColumnsOnResize(
       } else {
         if (nextDOM.style.width != cssWidth) {
           nextDOM.style.width = cssWidth;
-          nextDOM.style.minWidth = cssWidth.length ? '' : defaultCellMinWidth + 'px';
+          nextDOM.style.minWidth = cssWidth.length
+            ? ''
+            : defaultCellMinWidth + 'px';
         }
         nextDOM = nextDOM.nextSibling as HTMLElement;
       }


### PR DESCRIPTION
This PR separates `cellMinWidth` into `cellMinWidth` and `defaultCellMinWidth`.

With this, we can create new columns that are a bit wider (100px default) and have some "breathing space", while still have automatic (not fixed sizing). These columns can still be resized by the user to a width smaller than the initial "auto" width (`defaultCellMinWidth`) up to a minimum of `cellMinWidth`.

(Note: I think this is relevant only when your `table` is not set to 100% width)