### PR TITLE
fix: support defaultCellMinWidth in older Safari

### DIFF
--- a/src/columnresizing.ts
+++ b/src/columnresizing.ts
@@ -234,7 +234,12 @@ function handleMouseDown(
     }
   }
 
-  displayColumnWidth(view, pluginState.activeHandle, width, defaultCellMinWidth);
+  displayColumnWidth(
+    view,
+    pluginState.activeHandle,
+    width,
+    defaultCellMinWidth,
+  );
 
   win.addEventListener('mouseup', finish);
   win.addEventListener('mousemove', move);
@@ -400,11 +405,17 @@ export function handleDecorations(
       const dom = document.createElement('div');
       dom.className = 'column-resize-handle';
       if (columnResizingPluginKey.getState(state)?.dragging) {
-        decorations.push(Decoration.node(start + cellPos, start + cellPos + table.nodeAt(cellPos)!.nodeSize, {
-          class: 'column-resize-dragging'
-        }));
+        decorations.push(
+          Decoration.node(
+            start + cellPos,
+            start + cellPos + table.nodeAt(cellPos)!.nodeSize,
+            {
+              class: 'column-resize-dragging',
+            },
+          ),
+        );
       }
-      
+
       decorations.push(Decoration.widget(pos, dom));
     }
   }

--- a/src/columnresizing.ts
+++ b/src/columnresizing.ts
@@ -234,6 +234,8 @@ function handleMouseDown(
     }
   }
 
+  displayColumnWidth(view, pluginState.activeHandle, width, defaultCellMinWidth);
+
   win.addEventListener('mouseup', finish);
   win.addEventListener('mousemove', move);
   event.preventDefault();
@@ -397,6 +399,12 @@ export function handleDecorations(
       const pos = start + cellPos + table.nodeAt(cellPos)!.nodeSize - 1;
       const dom = document.createElement('div');
       dom.className = 'column-resize-handle';
+      if (columnResizingPluginKey.getState(state)?.dragging) {
+        decorations.push(Decoration.node(start + cellPos, start + cellPos + table.nodeAt(cellPos)!.nodeSize, {
+          class: 'column-resize-dragging'
+        }));
+      }
+      
       decorations.push(Decoration.widget(pos, dom));
     }
   }

--- a/src/tableview.ts
+++ b/src/tableview.ts
@@ -15,7 +15,10 @@ export class TableView implements NodeView {
     this.dom = document.createElement('div');
     this.dom.className = 'tableWrapper';
     this.table = this.dom.appendChild(document.createElement('table'));
-    this.table.style.setProperty('--default-cell-min-width', `${defaultCellMinWidth}px`);
+    this.table.style.setProperty(
+      '--default-cell-min-width',
+      `${defaultCellMinWidth}px`,
+    );
     this.colgroup = this.table.appendChild(document.createElement('colgroup'));
     updateColumnsOnResize(node, this.colgroup, this.table, defaultCellMinWidth);
     this.contentDOM = this.table.appendChild(document.createElement('tbody'));

--- a/src/tableview.ts
+++ b/src/tableview.ts
@@ -15,6 +15,7 @@ export class TableView implements NodeView {
     this.dom = document.createElement('div');
     this.dom.className = 'tableWrapper';
     this.table = this.dom.appendChild(document.createElement('table'));
+    this.table.style.setProperty('--default-cell-min-width', `${defaultCellMinWidth}px`);
     this.colgroup = this.table.appendChild(document.createElement('colgroup'));
     updateColumnsOnResize(node, this.colgroup, this.table, defaultCellMinWidth);
     this.contentDOM = this.table.appendChild(document.createElement('tbody'));
@@ -68,14 +69,10 @@ export function updateColumnsOnResize(
       if (!nextDOM) {
         const col = document.createElement('col');
         col.style.width = cssWidth;
-        col.style.minWidth = cssWidth.length ? '' : defaultCellMinWidth + 'px';
         colgroup.appendChild(col);
       } else {
         if (nextDOM.style.width != cssWidth) {
           nextDOM.style.width = cssWidth;
-          nextDOM.style.minWidth = cssWidth.length
-            ? ''
-            : defaultCellMinWidth + 'px';
         }
         nextDOM = nextDOM.nextSibling as HTMLElement;
       }

--- a/style/tables.css
+++ b/style/tables.css
@@ -4,7 +4,7 @@
 .ProseMirror table {
   border-collapse: collapse;
   table-layout: fixed;
-  width: 100%;
+  /* width: 100%; */
   overflow: hidden;
 }
 .ProseMirror td,
@@ -14,8 +14,8 @@
   position: relative;
 }
 
-.ProseMirror td:not([colwidth]):not(.column-resize-dragging),
-.ProseMirror th:not([colwidth]):not(.column-resize-dragging) {
+.ProseMirror td:not([data-colwidth]):not(.column-resize-dragging),
+.ProseMirror th:not([data-colwidth]):not(.column-resize-dragging) {
   /* if there's no explicit width set and the column is not being resized, set a default width */
   min-width: var(--default-cell-min-width);
 }

--- a/style/tables.css
+++ b/style/tables.css
@@ -4,7 +4,7 @@
 .ProseMirror table {
   border-collapse: collapse;
   table-layout: fixed;
-  /* width: 100%; */
+  width: 100%;
   overflow: hidden;
 }
 .ProseMirror td,

--- a/style/tables.css
+++ b/style/tables.css
@@ -13,6 +13,13 @@
   box-sizing: border-box;
   position: relative;
 }
+
+.ProseMirror td:not([colwidth]):not(.column-resize-dragging),
+.ProseMirror th:not([colwidth]):not(.column-resize-dragging) {
+  /* if there's no explicit width set and the column is not being resized, set a default width */
+  min-width: var(--default-cell-min-width);
+}
+
 .ProseMirror .column-resize-handle {
   position: absolute;
   right: -2px;


### PR DESCRIPTION
It turns out the approach taken in https://github.com/ProseMirror/prosemirror-tables/pull/253 was not supported well on safari. It doesn't support the `min-width` property on `col` elements.

This PR takes a new approach by setting the `min-width` on `<td>` and `<th>` elements directly. The selector makes sure this is only added when the cells don't have an explicit width (`colwidth`) set. We also needed to make sure the `min-width` is not set when we're actively resizing a column; because in this case, the cells will not have a `colwidth` yet as the resize action is "pending". To resolve this, we added a decoration to the cell nodes that are being resized.