### PR TITLE
fix: disable resizing when the editor view is uneditable

### DIFF
--- a/src/columnresizing.ts
+++ b/src/columnresizing.ts
@@ -142,7 +142,6 @@ function handleMouseMove(
   handleWidth: number,
   lastColumnResizable: boolean,
 ): void {
-  // check if editor is editable first before handling any events
   if (!view.editable) return;
 
   const pluginState = columnResizingPluginKey.getState(view.state);

--- a/src/columnresizing.ts
+++ b/src/columnresizing.ts
@@ -142,6 +142,9 @@ function handleMouseMove(
   handleWidth: number,
   lastColumnResizable: boolean,
 ): void {
+  // check if editor is editable first before handling any events
+  if (!view.editable) return;
+
   const pluginState = columnResizingPluginKey.getState(view.state);
   if (!pluginState) return;
 
@@ -178,6 +181,8 @@ function handleMouseMove(
 }
 
 function handleMouseLeave(view: EditorView): void {
+  if (!view.editable) return;
+
   const pluginState = columnResizingPluginKey.getState(view.state);
   if (pluginState && pluginState.activeHandle > -1 && !pluginState.dragging)
     updateHandle(view, -1);
@@ -189,6 +194,8 @@ function handleMouseDown(
   cellMinWidth: number,
   defaultCellMinWidth: number,
 ): boolean {
+  if (!view.editable) return false;
+
   const win = view.dom.ownerDocument.defaultView ?? window;
 
   const pluginState = columnResizingPluginKey.getState(view.state);

--- a/src/input.ts
+++ b/src/input.ts
@@ -178,7 +178,7 @@ export function handleMouseDown(
   view: EditorView,
   startEvent: MouseEvent,
 ): void {
-  if (startEvent.ctrlKey || startEvent.metaKey) return;
+  if (startEvent.ctrlKey || startEvent.metaKey || !view.editable) return;
 
   const startDOMCell = domInCell(view, startEvent.target as Node);
   let $anchor;

--- a/src/input.ts
+++ b/src/input.ts
@@ -178,7 +178,7 @@ export function handleMouseDown(
   view: EditorView,
   startEvent: MouseEvent,
 ): void {
-  if (startEvent.ctrlKey || startEvent.metaKey || !view.editable) return;
+  if (startEvent.ctrlKey || startEvent.metaKey) return;
 
   const startDOMCell = domInCell(view, startEvent.target as Node);
   let $anchor;


### PR DESCRIPTION
Right now when the view is set to being uneditable (so `view.editable` returns `false`), the cell selection & resizing will be handled. That's not really expected behavior. We could argue about cell selections still being valid but I think cell resizing should not be possible when the view is not editable.

This PR fixes those issues by preventing those DOM events of being handled.


## AI Summary

This pull request includes several changes to ensure that mouse event handlers only execute when the editor is editable.

### Enhancements to event handling:

* [`src/columnresizing.ts`](diffhunk://#diff-dc5d0fbef1c3d662f868f56a4aa568d1378610945029acffa4bb91635dd6f4eeR145-R147): Added checks in `handleMouseMove`, `handleMouseLeave`, and `handleMouseDown` functions to ensure that the editor is editable before handling any events. [[1]](diffhunk://#diff-dc5d0fbef1c3d662f868f56a4aa568d1378610945029acffa4bb91635dd6f4eeR145-R147) [[2]](diffhunk://#diff-dc5d0fbef1c3d662f868f56a4aa568d1378610945029acffa4bb91635dd6f4eeR184-R185) [[3]](diffhunk://#diff-dc5d0fbef1c3d662f868f56a4aa568d1378610945029acffa4bb91635dd6f4eeR197-R198)

* [`src/input.ts`](diffhunk://#diff-cb8cbffa623ff0975389e7e8c315e69d5e10345239ffe2c9b4b7986a56ad95efL181-R181): Modified the `handleMouseDown` function to return early if the editor is not editable, in addition to the existing checks for `ctrlKey` and `metaKey`.