### PR TITLE
fix: remove zero sized tables via `fixTables`

### DIFF
--- a/src/fixtables.ts
+++ b/src/fixtables.ts
@@ -114,9 +114,9 @@ export function fixTable(
         ...cell.attrs,
         colwidth: prob.colwidth,
       });
-    } else if (prob.type == 'zero_size') {
-      const pos = tr.mapping.map(tablePos)
-      tr.delete(pos, pos + table.nodeSize)
+    } else if (prob.type == 'zero_sized') {
+      const pos = tr.mapping.map(tablePos);
+      tr.delete(pos, pos + table.nodeSize);
     }
   }
   let first, last;

--- a/src/fixtables.ts
+++ b/src/fixtables.ts
@@ -114,6 +114,9 @@ export function fixTable(
         ...cell.attrs,
         colwidth: prob.colwidth,
       });
+    } else if (prob.type == 'zero_size') {
+      const pos = tr.mapping.map(tablePos)
+      tr.delete(pos, pos + table.nodeSize)
     }
   }
   let first, last;

--- a/src/tablemap.ts
+++ b/src/tablemap.ts
@@ -42,7 +42,7 @@ export type Problem =
       n: number;
     }
   | {
-      type: 'zero_size';
+      type: 'zero_sized';
     };
 
 let readFromCache: (key: Node) => TableMap | undefined;
@@ -299,7 +299,7 @@ function computeMap(table: Node): TableMap {
   }
 
   if (width === 0 || height === 0)
-    (problems || (problems = [])).push({ type: 'zero_size' });
+    (problems || (problems = [])).push({ type: 'zero_sized' });
 
   const tableMap = new TableMap(width, height, map, problems);
   let badWidths = false;

--- a/src/tablemap.ts
+++ b/src/tablemap.ts
@@ -40,6 +40,9 @@ export type Problem =
       type: 'overlong_rowspan';
       pos: number;
       n: number;
+    }
+  | {
+      type: 'zero_size';
     };
 
 let readFromCache: (key: Node) => TableMap | undefined;
@@ -294,6 +297,9 @@ function computeMap(table: Node): TableMap {
       (problems || (problems = [])).push({ type: 'missing', row, n: missing });
     pos++;
   }
+
+  if (width === 0 || height === 0)
+    (problems || (problems = [])).push({ type: 'zero_size' });
 
   const tableMap = new TableMap(width, height, map, problems);
   let badWidths = false;

--- a/test/fixtable.test.ts
+++ b/test/fixtable.test.ts
@@ -23,10 +23,10 @@ const cw100 = td({ colwidth: [100] }, p('x'));
 const cw200 = td({ colwidth: [200] }, p('x'));
 
 function fix(node: Node) {
-  const isdoc = node.type.name == 'doc';
-  const state = EditorState.create({ doc: isdoc ? node : doc(node) });
+  const isDoc = node.type === node.type.schema.topNodeType;
+  const state = EditorState.create({ doc: isDoc ? node : doc(node) });
   const tr = fixTables(state);
-  return tr && (isdoc ? tr.doc : tr.doc.firstChild);
+  return tr && (isDoc ? tr.doc : tr.doc.firstChild)!;
 }
 
 describe('fixTable', () => {

--- a/test/fixtable.test.ts
+++ b/test/fixtable.test.ts
@@ -22,10 +22,11 @@ import { fixTables } from '../src/';
 const cw100 = td({ colwidth: [100] }, p('x'));
 const cw200 = td({ colwidth: [200] }, p('x'));
 
-function fix(table: Node) {
-  const state = EditorState.create({ doc: doc(table) });
+function fix(node: Node) {
+  const isdoc = node.type.name == 'doc';
+  const state = EditorState.create({ doc: isdoc ? node : doc(node) });
   const tr = fixTables(state);
-  return tr && tr.doc.firstChild;
+  return tr && (isdoc ? tr.doc : tr.doc.firstChild);
 }
 
 describe('fixTable', () => {
@@ -125,5 +126,9 @@ describe('fixTable', () => {
       table(tr(h11, hEmpty, hEmpty), tr(cEmpty, c11, c11), tr(c(3, 1))),
       eq,
     );
+  });
+
+  it('will remove zero-sized table', () => {
+    ist(fix(doc(table(tr()), table(tr(c11)))), doc(table(tr(c11))), eq);
   });
 });


### PR DESCRIPTION
For context, see https://github.com/ProseMirror/prosemirror/issues/1506