### PR TITLE
fix: clear native text selection when starting cross-cell drag

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -239,6 +239,13 @@ export function handleMouseDown(
       // Moving out of the initial cell -- start a new cell selection
       $anchor = cellUnderMouse(view, startEvent);
       if (!$anchor) return stop();
+      // Clear browser's native text selection when starting cross-cell selection
+      // This prevents text from being selected when first dragging across cells
+      const root = view.root as Document;
+      if (root.getSelection) {
+        const domSel = root.getSelection();
+        if (domSel) domSel.removeAllRanges();
+      }
     }
     if ($anchor) setCellSelection($anchor, event);
   }


### PR DESCRIPTION
### Problem

When dragging to extend cell selection from the second cell backwards, the browser's native text selection would be triggered on the first drag, causing cell content to be visually selected. This issue only occurred on the first drag - subsequent drags without releasing the mouse worked correctly.

**Before:**

![20251230205753_rec_](https://github.com/user-attachments/assets/b85c775f-636c-412a-8c19-2b7adc58230c)

### Solution

Clear the browser's native text selection when a cross-cell drag is first detected. This prevents the native selection from interfering with the custom `CellSelection` behavior.

The fix adds `removeAllRanges()` call when the mouse first moves out of the starting cell, ensuring a clean cell selection experience from the start.

**After:**

![20251230205953_rec_](https://github.com/user-attachments/assets/e0e7781c-b262-4aee-b83d-99aa2f712d67)

### Changes

- Modified `handleMouseDown` function in `src/input.ts`
- Added native selection clearing when cross-cell selection begins
- All existing tests pass
