### PR TITLE
fix: end a cell drag when the mouseup is lost

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -230,6 +230,10 @@ export function handleMouseDown(
 
   function move(_event: Event): void {
     const event = _event as MouseEvent;
+    // The mouseup that should have ended this gesture was never delivered, so
+    // end it here instead of extending the selection under a released button.
+    if (event.buttons == 0) return stop();
+
     const anchor = tableEditingKey.getState(view.state);
     let $anchor;
     if (anchor != null) {


### PR DESCRIPTION
Closes #341.

## Problem

`handleMouseDown` extends the cell selection on every `mousemove` until it sees a `mouseup`, and never checks whether a button is still held. If that `mouseup` is not delivered, the gesture never ends: the selection keeps following the pointer around the table with nothing pressed, until the user clicks somewhere else.

A `mouseup` genuinely can go missing. The button is released outside the window, focus moves to another application, the OS or browser cancels the sequence, or an unrelated handler calls `stopPropagation()` somewhere between the cell and `view.root`, since `stop` is registered in the bubble phase.

## Fix

```ts
if (event.buttons == 0) return stop();
```

`stop()` already removes the three listeners before dispatching the meta that clears the anchor, so calling it here both ends the selection and releases the handlers. Clearing `tableEditingKey` without `stop()` would not be enough on its own, because the `mousemove` listener would stay installed and could start a fresh selection on the next movement.

## Why this shape

Every sibling gesture in the two packages already guards against exactly this, and this is the only one that does not:

| Gesture | Guard |
|---|---|
| `prosemirror-view` `MouseDown.move` | `if (event.buttons == 0) this.done()` |
| `prosemirror-view` content drag `move` | `if (event.buttons == 0 \|\| ...) { this.done(); return }` |
| `prosemirror-tables` `columnResizing` `move` | `if (!event.which) return finish(event)` |
| `prosemirror-tables` cell selection `move` | none, until this PR |

`prosemirror-view` added its guard for this precise failure mode. From its changelog, 1.18.4 (2021-04-27):

> Fixes an issue where, when mouseup events weren't being delivered, the editor could leak event handlers.

There is precedent in this repository too. #17 ("Stop cell-selecting when a dragstart event occurs") described the editor being *"stuck in cell-selecting mode though the mouse button was released"* and added `dragstart` as a second termination condition; this covers the general case. #324 similarly hardened this same function for the context-menu case.

## Verification

`pnpm run typecheck` passes and all 179 tests pass. The two `prefer-const` lint errors in `src/input.ts` are present on an unmodified `master` as well, so I have left them alone.

I did not add a test: the suite has no harness for driving mouse gestures through a mounted `EditorView`, and reproducing this needs `posAtCoords` hit-testing, which is unreliable under jsdom. Happy to add one if you would like a particular approach.

The failure is straightforward to demonstrate in a browser against an editor with a table:

```js
const cell = (n) => document.querySelectorAll('.ProseMirror td')[n];
const fire = (type, el, buttons) => {
    const r = el.getBoundingClientRect();
    el.dispatchEvent(new MouseEvent(type, {
        bubbles: true, button: 0, buttons,
        clientX: r.left + r.width / 2, clientY: r.top + r.height / 2,
    }));
};

fire('mousedown', cell(0), 1);
fire('mousemove', cell(1), 1);   // two cells selected, as expected
// no mouseup is delivered
fire('mousemove', cell(5), 0);   // buttons: 0, yet the whole table is now selected
```

With this change the third call ends the gesture instead of extending it.

## Optional follow-up

`stop` is registered in the bubble phase:

```ts
view.root.addEventListener('mouseup', stop);
view.root.addEventListener('dragstart', stop);
```

so an unrelated `stopPropagation()` on `mouseup` between the cell and `view.root` also strands the gesture. Registering those two with `capture: true` would close that path. I have left it out of this PR since it is robustness rather than a correctness bug, but happy to add it here or separately if you want it.
